### PR TITLE
Show crossing observation timestamps

### DIFF
--- a/static/css/level-crossing.css
+++ b/static/css/level-crossing.css
@@ -339,6 +339,22 @@
 .crossing-state-opening { background: #e2ecf8; color: #245b87; }
 .crossing-form-result { min-height: 20px; margin: 0; color: var(--crossing-green) !important; font-size: 0.86rem; }
 
+.crossing-observation-history { grid-column: 1 / -1; border-top: 1px solid var(--crossing-line); padding-top: 16px; }
+.crossing-observation-history summary { color: #245b87; font-weight: 750; cursor: pointer; }
+.crossing-observation-history ol { display: grid; gap: 8px; margin: 14px 0 0; padding: 0; list-style: none; }
+.crossing-observation-history li {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) auto;
+  gap: 3px 18px;
+  padding: 10px 12px;
+  border-radius: 9px;
+  background: #ffffff;
+  color: #334e68;
+  font-size: 0.8rem;
+}
+.crossing-observation-history time { color: var(--crossing-muted); text-align: right; }
+.crossing-observation-note { grid-column: 1 / -1; color: var(--crossing-muted); }
+
 .crossing-safety-note {
   margin: 24px 0;
   padding: 16px 18px;
@@ -370,5 +386,7 @@
   .level-crossing-page .site-main > .site-shell { width: min(100% - 22px, 1120px); }
   .crossing-route-advice { border-radius: 18px; }
   .crossing-state-buttons { grid-template-columns: 1fr 1fr; }
+  .crossing-observation-history li { grid-template-columns: 1fr; }
+  .crossing-observation-history time { text-align: left; }
   .crossing-monitor__footer { flex-direction: column; }
 }

--- a/static/js/level-crossing.js
+++ b/static/js/level-crossing.js
@@ -61,6 +61,8 @@
   const observationNote = document.getElementById("crossing-observation-note");
   const observationResult = document.getElementById("crossing-observation-result");
   const observationCount = document.getElementById("crossing-observation-count");
+  const observationHistory = document.getElementById("crossing-observation-history");
+  const observationRows = document.getElementById("crossing-observation-rows");
   const lastUpdated = document.getElementById("crossing-last-updated");
   const modeBadge = document.querySelector(".crossing-mode-badge");
   const feedStatus = document.getElementById("crossing-feed-status");
@@ -121,8 +123,8 @@
       return {
         state: "LIKELY_CLOSED",
         reason: active.trains.length > 1
-          ? `${active.trains.length} closely spaced trains may keep the barriers down.`
-          : "A train is inside the predicted closure window.",
+          ? `The demo pattern groups ${active.trains.length} trains here; the live feed has not confirmed that sequence.`
+          : "One demo train is inside the predicted closure window; the live feed has not confirmed it.",
         eventAt: active.end,
         eventLabel: "Predicted reopening",
         waitSeconds: Math.max(0, Math.round((active.end.getTime() - now.getTime()) / 1000)),
@@ -133,7 +135,7 @@
     if (next && next.start.getTime() - now.getTime() <= 180 * 1000) {
       return {
         state: "CLOSING_SOON",
-        reason: "The next predicted closure begins within three minutes.",
+        reason: "The next demo closure begins within three minutes; the live feed has not confirmed it.",
         eventAt: next.start,
         eventLabel: "Predicted closing",
         waitSeconds: Math.max(0, Math.round((next.end.getTime() - now.getTime()) / 1000)),
@@ -143,7 +145,7 @@
 
     return {
       state: "OPEN",
-      reason: "No train is currently inside the predicted closure window.",
+      reason: "No train is currently inside the demonstration closure window.",
       eventAt: next?.start || null,
       eventLabel: "Next predicted closing",
       waitSeconds: 0,
@@ -183,10 +185,40 @@
     }
   }
 
-  function renderObservationCount() {
-    const count = readObservations().length;
+  function formatObservationTime(value) {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "Time unavailable";
+    return new Intl.DateTimeFormat("en-GB", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      timeZone: "Europe/London",
+      timeZoneName: "short"
+    }).format(date);
+  }
+
+  function renderObservations() {
+    const observations = readObservations();
+    const count = observations.length;
     observationCount.hidden = count === 0;
     observationCount.querySelector("strong").textContent = count;
+    observationHistory.hidden = count === 0;
+    observationRows.innerHTML = observations.slice(0, 10).map((observation) => {
+      const crossing = crossings.find(({ id }) => id === observation.crossingId);
+      const state = String(observation.state || "Unknown").toLowerCase();
+      const label = state.charAt(0).toUpperCase() + state.slice(1);
+      const note = observation.note
+        ? `<span class="crossing-observation-note">${escapeHtml(observation.note)}</span>`
+        : "";
+      return `<li>
+        <strong>${escapeHtml(crossing?.name || observation.crossingId || "Crossing")} · ${escapeHtml(label)}</strong>
+        <time datetime="${escapeHtml(observation.observedAt || "")}">${escapeHtml(formatObservationTime(observation.observedAt))}</time>
+        ${note}
+      </li>`;
+    }).join("");
   }
 
   function formatFeedTime(value) {
@@ -271,7 +303,7 @@
     crossingGrid.innerHTML = predictions.map(({ crossing, prediction }) => {
       const [label, statusClass] = stateDetails[prediction.state];
       const nextTrain = prediction.trains[0]
-        ? `<span>Next train: ${escapeHtml(prediction.trains[0].destination)} · ${escapeHtml(prediction.trains[0].direction)}</span>`
+        ? `<span>Demo train: ${escapeHtml(prediction.trains[0].destination)} · ${escapeHtml(prediction.trains[0].direction)}</span>`
         : "";
       return `
         <article class="crossing-card${crossing.primary ? " crossing-card--primary" : ""}">
@@ -313,11 +345,11 @@
     const observations = [observation, ...readObservations()].slice(0, 100);
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(observations));
     observationNote.value = "";
-    observationResult.textContent = `${submitter.textContent} recorded for ${crossing?.name || "the crossing"}.`;
-    renderObservationCount();
+    observationResult.textContent = `${submitter.textContent} recorded for ${crossing?.name || "the crossing"} at ${formatObservationTime(observation.observedAt)}.`;
+    renderObservations();
   });
 
-  renderObservationCount();
+  renderObservations();
   render();
   loadFeedStatus();
   window.setInterval(render, 30000);

--- a/templates/level-crossing.html
+++ b/templates/level-crossing.html
@@ -4,7 +4,7 @@
 
 {% block head_extra %}
   <meta name="description" content="Predicted status for Whyke Road, Stockbridge Road and Basin Road level crossings, with route guidance into Chichester.">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/level-crossing.css') }}?v=1">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/level-crossing.css') }}?v=2">
 {% endblock %}
 
 {% block body_class %} level-crossing-page{% endblock %}
@@ -69,8 +69,9 @@
       <p class="crossing-eyebrow">Calibration</p>
       <h2>What can you see?</h2>
       <p>
-        Log the physical barrier state when you happen to observe it. These records stay on this
-        device and will help us design the live calibration workflow.
+        Log the physical barrier state when you happen to observe it. Records are timestamped and
+        stay on this device for now; they help us calibrate the live feed without collecting your
+        location or identity.
       </p>
       <div id="crossing-observation-count" class="crossing-observation-count" hidden>
         <strong>0</strong>
@@ -96,6 +97,11 @@
       <input id="crossing-observation-note" name="note" maxlength="300" placeholder="For example: second train approaching">
       <p id="crossing-observation-result" class="crossing-form-result" aria-live="polite"></p>
     </form>
+
+    <details id="crossing-observation-history" class="crossing-observation-history" hidden>
+      <summary>Recent observations on this device</summary>
+      <ol id="crossing-observation-rows"></ol>
+    </details>
   </section>
 
   <aside class="crossing-safety-note">
@@ -112,5 +118,5 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ url_for('static', filename='js/level-crossing.js') }}?v=1"></script>
+  <script src="{{ url_for('static', filename='js/level-crossing.js') }}?v=2"></script>
 {% endblock %}

--- a/tests/test_level_crossing.py
+++ b/tests/test_level_crossing.py
@@ -19,6 +19,7 @@ class LevelCrossingPageTests(unittest.TestCase):
         self.assertIn(b"Whyke Road", response.data)
         self.assertIn(b"Simulation mode", response.data)
         self.assertIn(b"Route-planning prediction only", response.data)
+        self.assertIn(b"Recent observations on this device", response.data)
         css_response = self.client.get("/static/css/level-crossing.css")
         js_response = self.client.get("/static/js/level-crossing.js")
         self.assertEqual(css_response.status_code, 200)


### PR DESCRIPTION
## What changed

- shows the ten most recent crossing observations stored on the current device
- displays exact UK date, time, seconds, and BST/GMT timezone
- confirms the timestamp immediately after a report is recorded
- labels simulated train sequences clearly so they are not mistaken for TD-confirmed movements

## Why

The first Whyke Road field report was useful, but its timestamp was hidden in mobile Chrome local storage and the demo sequence suggested three trains when only one passed.

## Validation

- `node --check static/js/level-crossing.js`
- full Python suite: 114 tests passed
- verified `2026-07-31T15:25:00Z` renders as `31 Jul 2026, 16:25:00 BST`