### PR TITLE
Add crossing selection and calibration sessions

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,12 @@ from services.data_explorer.eda_engine import (
 )
 from services.sports_editorial import sports_editorial_workspace
 from services.level_crossing.td_feed import td_feed
+from services.level_crossing.observations import (
+    ObservationValidationError,
+    observation_rate_limiter,
+    observation_store,
+)
+from services.sports_editorial.supabase_rest import SupabaseError
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("FLASK_SECRET_KEY", "sports-editorial-pilot-dev-only")
@@ -49,6 +55,22 @@ def level_crossing():
 def level_crossing_td_status():
     td_feed.start()
     return jsonify(td_feed.snapshot())
+
+
+@app.route("/api/level-crossing/observations", methods=["POST"])
+def level_crossing_observations():
+    if not observation_rate_limiter.allow(request.remote_addr):
+        return jsonify({"saved": False, "error": "Too many observations. Please wait and try again."}), 429
+
+    td_feed.start()
+    try:
+        saved = observation_store.save(request.get_json(silent=True), td_feed.snapshot())
+    except ObservationValidationError as error:
+        return jsonify({"saved": False, "error": str(error)}), 400
+    except SupabaseError:
+        return jsonify({"saved": False, "error": "Central observation storage is unavailable."}), 503
+
+    return jsonify({"saved": True, "id": saved["id"]}), 201
 
 
 @app.route("/gcse/history")

--- a/services/level_crossing/observations.py
+++ b/services/level_crossing/observations.py
@@ -1,0 +1,143 @@
+"""Validation and durable storage for anonymous level-crossing observations."""
+
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+import json
+import re
+import threading
+
+from services.sports_editorial.supabase_rest import SupabaseRestClient
+
+
+CROSSINGS = {
+    "whyke-road": {"name": "Whyke Road", "what3words": "awake.mason.melon"},
+    "basin-road": {"name": "Basin Road", "what3words": "cubs.glare.photo"},
+    "stockbridge-road": {"name": "Stockbridge Road", "what3words": "placed.bless.dance"},
+}
+STATES = {"OPEN", "CLOSING", "CLOSED", "OPENING", "TRAIN_PASSED"}
+EVENT_KINDS = {"quick", "watch"}
+IDENTIFIER = re.compile(r"^[A-Za-z0-9_-]{8,80}$")
+
+
+class ObservationValidationError(ValueError):
+    pass
+
+
+def _parse_timestamp(value):
+    if not isinstance(value, str) or not value.strip():
+        raise ObservationValidationError("Observation time is required.")
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ObservationValidationError("Observation time is invalid.") from error
+    if parsed.tzinfo is None:
+        raise ObservationValidationError("Observation time must include a timezone.")
+    parsed = parsed.astimezone(timezone.utc)
+    now = datetime.now(timezone.utc)
+    if parsed > now + timedelta(minutes=5) or parsed < now - timedelta(days=30):
+        raise ObservationValidationError("Observation time is outside the accepted range.")
+    return parsed.isoformat()
+
+
+def _safe_json_object(value, label, max_length=5000):
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ObservationValidationError(f"{label} must be an object.")
+    encoded = json.dumps(value, separators=(",", ":"))
+    if len(encoded) > max_length:
+        raise ObservationValidationError(f"{label} is too large.")
+    return json.loads(encoded)
+
+
+class ObservationRateLimiter:
+    """Small process-local guard against accidental or automated public endpoint spam."""
+
+    def __init__(self, limit=60, window_seconds=300):
+        self.limit = limit
+        self.window = timedelta(seconds=window_seconds)
+        self._events = defaultdict(deque)
+        self._lock = threading.Lock()
+
+    def allow(self, key, now=None):
+        now = now or datetime.now(timezone.utc)
+        with self._lock:
+            events = self._events[str(key or "unknown")]
+            cutoff = now - self.window
+            while events and events[0] <= cutoff:
+                events.popleft()
+            if len(events) >= self.limit:
+                return False
+            events.append(now)
+            return True
+
+
+class LevelCrossingObservationStore:
+    def __init__(self, client=None):
+        self.client = client or SupabaseRestClient()
+
+    @property
+    def configured(self):
+        return self.client.configured
+
+    def build_row(self, payload, td_snapshot):
+        if not isinstance(payload, dict):
+            raise ObservationValidationError("A JSON observation is required.")
+
+        observation_id = str(payload.get("id", "")).strip()
+        session_id = str(payload.get("sessionId", "")).strip()
+        crossing_id = str(payload.get("crossingId", "")).strip()
+        state = str(payload.get("state", "")).strip().upper()
+        event_kind = str(payload.get("eventKind", "quick")).strip().lower()
+        note = str(payload.get("note", "")).strip()
+
+        if not IDENTIFIER.fullmatch(observation_id):
+            raise ObservationValidationError("Observation identifier is invalid.")
+        if session_id and not IDENTIFIER.fullmatch(session_id):
+            raise ObservationValidationError("Watch-session identifier is invalid.")
+        if crossing_id not in CROSSINGS:
+            raise ObservationValidationError("Crossing is not recognised.")
+        if state not in STATES:
+            raise ObservationValidationError("Barrier state is not recognised.")
+        if event_kind not in EVENT_KINDS:
+            raise ObservationValidationError("Observation type is not recognised.")
+        if len(note) > 300:
+            raise ObservationValidationError("Observation note is too long.")
+
+        snapshot = td_snapshot if isinstance(td_snapshot, dict) else {}
+        safe_snapshot = {
+            "area": snapshot.get("area"),
+            "status": snapshot.get("status"),
+            "lastMessageAt": snapshot.get("lastMessageAt"),
+            "messageCount": snapshot.get("messageCount", 0),
+            "recentEvents": list(snapshot.get("recentEvents") or [])[:12],
+            "activeBerths": dict(snapshot.get("activeBerths") or {}),
+        }
+
+        return {
+            "id": observation_id,
+            "crossing_id": crossing_id,
+            "crossing_name": CROSSINGS[crossing_id]["name"],
+            "what3words": CROSSINGS[crossing_id]["what3words"],
+            "state": state,
+            "event_kind": event_kind,
+            "observed_at": _parse_timestamp(payload.get("observedAt")),
+            "session_id": session_id or None,
+            "note": note or None,
+            "client_prediction": _safe_json_object(payload.get("prediction"), "Prediction"),
+            "td_snapshot": _safe_json_object(safe_snapshot, "TD snapshot", max_length=20000),
+        }
+
+    def save(self, payload, td_snapshot):
+        row = self.build_row(payload, td_snapshot)
+        result = self.client.request(
+            "level_crossing_observations",
+            "POST",
+            payload=row,
+            prefer="resolution=merge-duplicates,return=representation",
+        )
+        return result[0] if isinstance(result, list) and result else row
+
+
+observation_store = LevelCrossingObservationStore()
+observation_rate_limiter = ObservationRateLimiter()

--- a/static/css/level-crossing.css
+++ b/static/css/level-crossing.css
@@ -80,6 +80,54 @@
   font-weight: 800;
 }
 
+.crossing-selection-panel {
+  margin: 8px 0 22px;
+  padding: clamp(18px, 3vw, 26px);
+  border: 1px solid var(--crossing-line);
+  border-radius: 18px;
+  background: var(--crossing-surface);
+  box-shadow: 0 8px 24px rgba(16, 42, 67, 0.06);
+}
+
+.crossing-selection-heading {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 20px;
+}
+.crossing-selection-heading h2 { margin-bottom: 4px; font-size: clamp(1.2rem, 3vw, 1.55rem); }
+.crossing-selection-heading p { margin-bottom: 0; color: var(--crossing-muted); }
+.crossing-selection-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+.crossing-selection-chip,
+.crossing-selection-empty {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: #edf2f7;
+  color: #334e68;
+  font-size: 0.8rem;
+  font-weight: 750;
+}
+.crossing-selection-chip--primary { background: #e4f2fb; color: #175b89; }
+.crossing-selection-controls { margin-top: 18px; padding-top: 18px; border-top: 1px solid var(--crossing-line); }
+.crossing-selection-controls h3 { margin: 0 0 4px; }
+.crossing-selection-controls > p { color: var(--crossing-muted); font-size: 0.84rem; }
+.crossing-selection-option {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid #edf2f7;
+}
+.crossing-selection-option label { display: flex; align-items: center; gap: 10px; cursor: pointer; }
+.crossing-selection-option input { width: 18px; height: 18px; accent-color: var(--crossing-blue); }
+.crossing-selection-option span { display: grid; gap: 2px; }
+.crossing-selection-option small { color: var(--crossing-muted); }
+.crossing-primary-choice { color: #245b87; font-size: 0.8rem; font-weight: 750; }
+
 .crossing-route-advice {
   position: relative;
   overflow: hidden;
@@ -139,9 +187,10 @@
 
 .crossing-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
   gap: 16px;
 }
+.crossing-grid-empty { grid-column: 1 / -1; padding: 22px; border-radius: 14px; background: #ffffff; color: var(--crossing-muted); }
 
 .crossing-card {
   padding: 22px;
@@ -229,6 +278,7 @@
   transform: translateY(-1px);
   box-shadow: 0 5px 12px rgba(16, 42, 67, 0.1);
 }
+.crossing-button:disabled { opacity: 0.5; cursor: not-allowed; transform: none; box-shadow: none; }
 
 .crossing-button:focus-visible,
 .crossing-monitor input:focus-visible,
@@ -354,6 +404,39 @@
 }
 .crossing-observation-history time { color: var(--crossing-muted); text-align: right; }
 .crossing-observation-note { grid-column: 1 / -1; color: var(--crossing-muted); }
+.crossing-observation-sync { grid-column: 1 / -1; color: #8a4b08; font-size: 0.72rem; font-weight: 750; }
+.crossing-observation-sync--saved { color: var(--crossing-green); }
+
+.crossing-watch-panel {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(0, 1.2fr);
+  gap: 24px;
+  margin-top: 4px;
+  padding: 20px;
+  border: 1px solid #b9d9ee;
+  border-radius: 16px;
+  background: #f8fcff;
+}
+.crossing-watch-panel h3 { margin: 0 0 7px; font-size: 1.2rem; }
+.crossing-watch-panel label { display: block; margin-bottom: 6px; }
+.crossing-watch-panel select { margin-bottom: 10px; }
+.crossing-watch-start { width: 100%; background: var(--crossing-blue); color: #ffffff; }
+.crossing-watch-active { display: grid; align-content: start; gap: 12px; }
+.crossing-watch-active[hidden] { display: none; }
+.crossing-watch-status {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 4px 16px;
+  padding: 14px;
+  border-radius: 12px;
+  background: #ffffff;
+  color: #334e68;
+}
+.crossing-watch-status > strong { grid-row: 1 / 3; grid-column: 2; align-self: center; color: var(--crossing-blue); font-size: 1.45rem; }
+.crossing-watch-status > span:last-child { font-size: 0.78rem; color: var(--crossing-muted); }
+.crossing-watch-buttons { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 7px; }
+.crossing-watch-train { background: #dcecff; color: #175b89; }
 
 .crossing-safety-note {
   margin: 24px 0;
@@ -380,11 +463,17 @@
   .crossing-prediction-reason { min-height: 0; }
   .crossing-observation-panel { grid-template-columns: 1fr; }
   .crossing-feed-panel { grid-template-columns: 1fr; }
+  .crossing-watch-panel { grid-template-columns: 1fr; }
+  .crossing-watch-buttons { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 520px) {
   .level-crossing-page .site-main > .site-shell { width: min(100% - 22px, 1120px); }
   .crossing-route-advice { border-radius: 18px; }
+  .crossing-selection-heading { display: grid; }
+  .crossing-selection-heading .crossing-button { width: 100%; }
+  .crossing-selection-option { grid-template-columns: 1fr; }
+  .crossing-primary-choice { margin-left: 28px; }
   .crossing-state-buttons { grid-template-columns: 1fr 1fr; }
   .crossing-observation-history li { grid-template-columns: 1fr; }
   .crossing-observation-history time { text-align: left; }

--- a/static/js/level-crossing.js
+++ b/static/js/level-crossing.js
@@ -2,12 +2,14 @@
   "use strict";
 
   const STORAGE_KEY = "chichester-crossing-observations";
+  const PREFERENCES_KEY = "level-crossing-monitor-preferences-v1";
   const crossings = [
     {
       id: "whyke-road",
       name: "Whyke Road",
+      area: "Chichester",
+      what3words: "awake.mason.melon",
       type: "Manually controlled barriers · CCTV monitored",
-      primary: true,
       baselineDriveSeconds: 450,
       closingLeadSeconds: 95,
       clearanceSeconds: 45,
@@ -15,26 +17,28 @@
       minutes: [2, 8, 16, 24, 30, 32, 34, 45, 53]
     },
     {
-      id: "stockbridge-road",
-      name: "Stockbridge Road",
-      type: "Manually controlled barriers · CCTV monitored",
-      primary: false,
-      baselineDriveSeconds: 510,
-      closingLeadSeconds: 100,
-      clearanceSeconds: 50,
-      holdGapSeconds: 130,
-      minutes: [4, 10, 18, 26, 31, 33, 35, 47, 55]
-    },
-    {
       id: "basin-road",
       name: "Basin Road",
+      area: "Chichester",
+      what3words: "cubs.glare.photo",
       type: "Manually controlled barriers · CCTV monitored",
-      primary: false,
       baselineDriveSeconds: 525,
       closingLeadSeconds: 100,
       clearanceSeconds: 50,
       holdGapSeconds: 130,
       minutes: [3, 9, 17, 25, 31, 33, 35, 46, 54]
+    },
+    {
+      id: "stockbridge-road",
+      name: "Stockbridge Road",
+      area: "Chichester",
+      what3words: "placed.bless.dance",
+      type: "Manually controlled barriers · CCTV monitored",
+      baselineDriveSeconds: 510,
+      closingLeadSeconds: 100,
+      clearanceSeconds: 50,
+      holdGapSeconds: 130,
+      minutes: [4, 10, 18, 26, 31, 33, 35, 47, 55]
     }
   ];
 
@@ -52,46 +56,161 @@
     LIKELY_CLOSED: ["Likely closed", "crossing-status--closed"],
     UNKNOWN: ["Unknown", "crossing-status--unknown"]
   };
+  const observationLabels = {
+    OPEN: "Open",
+    CLOSING: "Closing",
+    CLOSED: "Closed",
+    OPENING: "Opening",
+    TRAIN_PASSED: "Train passed"
+  };
 
-  const routeAdvice = document.getElementById("crossing-route-advice");
-  const crossingGrid = document.getElementById("crossing-grid");
-  const refreshButton = document.getElementById("crossing-refresh");
-  const observationForm = document.getElementById("crossing-observation-form");
-  const observationSelect = document.getElementById("crossing-observation-select");
-  const observationNote = document.getElementById("crossing-observation-note");
-  const observationResult = document.getElementById("crossing-observation-result");
-  const observationCount = document.getElementById("crossing-observation-count");
-  const observationHistory = document.getElementById("crossing-observation-history");
-  const observationRows = document.getElementById("crossing-observation-rows");
-  const lastUpdated = document.getElementById("crossing-last-updated");
-  const modeBadge = document.querySelector(".crossing-mode-badge");
-  const feedStatus = document.getElementById("crossing-feed-status");
-  const feedCopy = document.getElementById("crossing-feed-copy");
-  const feedArea = document.getElementById("crossing-feed-area");
-  const feedFrames = document.getElementById("crossing-feed-frames");
-  const feedCount = document.getElementById("crossing-feed-count");
-  const feedUpdated = document.getElementById("crossing-feed-updated");
-  const feedEvents = document.getElementById("crossing-feed-events");
-  const feedEventRows = document.getElementById("crossing-feed-event-rows");
+  const elements = {
+    routeAdvice: document.getElementById("crossing-route-advice"),
+    crossingGrid: document.getElementById("crossing-grid"),
+    refreshButton: document.getElementById("crossing-refresh"),
+    selectionSummary: document.getElementById("crossing-selection-summary"),
+    selectionChips: document.getElementById("crossing-selection-chips"),
+    selectionToggle: document.getElementById("crossing-selection-toggle"),
+    selectionControls: document.getElementById("crossing-selection-controls"),
+    selectionOptions: document.getElementById("crossing-selection-options"),
+    observationForm: document.getElementById("crossing-observation-form"),
+    observationSelect: document.getElementById("crossing-observation-select"),
+    observationNote: document.getElementById("crossing-observation-note"),
+    observationResult: document.getElementById("crossing-observation-result"),
+    observationCount: document.getElementById("crossing-observation-count"),
+    observationHistory: document.getElementById("crossing-observation-history"),
+    observationRows: document.getElementById("crossing-observation-rows"),
+    watchSelect: document.getElementById("crossing-watch-select"),
+    watchStart: document.getElementById("crossing-watch-start"),
+    watchActive: document.getElementById("crossing-watch-active"),
+    watchName: document.getElementById("crossing-watch-name"),
+    watchElapsed: document.getElementById("crossing-watch-elapsed"),
+    watchTrainCount: document.getElementById("crossing-watch-train-count"),
+    watchFinish: document.getElementById("crossing-watch-finish"),
+    watchResult: document.getElementById("crossing-watch-result"),
+    lastUpdated: document.getElementById("crossing-last-updated"),
+    modeBadge: document.querySelector(".crossing-mode-badge"),
+    feedStatus: document.getElementById("crossing-feed-status"),
+    feedCopy: document.getElementById("crossing-feed-copy"),
+    feedArea: document.getElementById("crossing-feed-area"),
+    feedFrames: document.getElementById("crossing-feed-frames"),
+    feedCount: document.getElementById("crossing-feed-count"),
+    feedUpdated: document.getElementById("crossing-feed-updated"),
+    feedEvents: document.getElementById("crossing-feed-events"),
+    feedEventRows: document.getElementById("crossing-feed-event-rows")
+  };
 
-  if (!routeAdvice || !crossingGrid || !refreshButton || !observationForm) return;
+  if (!elements.routeAdvice || !elements.crossingGrid || !elements.observationForm) return;
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function readJson(key, fallback) {
+    try {
+      const value = JSON.parse(window.localStorage.getItem(key) || "null");
+      return value === null ? fallback : value;
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function readPreferences() {
+    const stored = readJson(PREFERENCES_KEY, {});
+    const validIds = new Set(crossings.map(({ id }) => id));
+    const selectedIds = Array.isArray(stored.selectedIds)
+      ? stored.selectedIds.filter((id) => validIds.has(id))
+      : crossings.map(({ id }) => id);
+    const primaryId = selectedIds.includes(stored.primaryId)
+      ? stored.primaryId
+      : (selectedIds.includes("whyke-road") ? "whyke-road" : selectedIds[0] || null);
+    return { selectedIds, primaryId };
+  }
+
+  let preferences = readPreferences();
+  let watchSession = null;
+
+  function savePreferences() {
+    window.localStorage.setItem(PREFERENCES_KEY, JSON.stringify(preferences));
+  }
+
+  function selectedCrossings() {
+    return crossings.filter(({ id }) => preferences.selectedIds.includes(id));
+  }
+
+  function ensurePrimary() {
+    if (!preferences.selectedIds.includes(preferences.primaryId)) {
+      preferences.primaryId = preferences.selectedIds[0] || null;
+    }
+  }
+
+  function renderSelection() {
+    ensurePrimary();
+    const selected = selectedCrossings();
+    elements.selectionSummary.textContent = selected.length
+      ? `${selected.length} crossing${selected.length === 1 ? "" : "s"} selected. The star marks the crossing used for route advice.`
+      : "No crossings selected. Choose at least one to see predictions and record observations.";
+    elements.selectionChips.innerHTML = selected.length
+      ? selected.map((crossing) => `<span class="crossing-selection-chip${crossing.id === preferences.primaryId ? " crossing-selection-chip--primary" : ""}">
+          ${crossing.id === preferences.primaryId ? '<span aria-hidden="true">★</span>' : ""}${escapeHtml(crossing.name)}
+        </span>`).join("")
+      : '<span class="crossing-selection-empty">None selected</span>';
+
+    elements.selectionOptions.innerHTML = crossings.map((crossing) => {
+      const selectedHere = preferences.selectedIds.includes(crossing.id);
+      return `<div class="crossing-selection-option">
+        <label>
+          <input type="checkbox" data-crossing-select="${escapeHtml(crossing.id)}" ${selectedHere ? "checked" : ""}>
+          <span><strong>${escapeHtml(crossing.name)}</strong><small>///${escapeHtml(crossing.what3words)}</small></span>
+        </label>
+        <label class="crossing-primary-choice">
+          <input type="radio" name="primary-crossing" data-crossing-primary="${escapeHtml(crossing.id)}" ${crossing.id === preferences.primaryId ? "checked" : ""} ${selectedHere ? "" : "disabled"}>
+          Primary
+        </label>
+      </div>`;
+    }).join("");
+    populateCrossingSelects();
+  }
+
+  function populateSelect(select, previousValue) {
+    const selected = selectedCrossings();
+    select.innerHTML = "";
+    if (!selected.length) {
+      select.add(new Option("Select a crossing above", ""));
+      select.disabled = true;
+      return;
+    }
+    select.disabled = false;
+    selected.forEach((crossing) => select.add(new Option(crossing.name, crossing.id)));
+    select.value = selected.some(({ id }) => id === previousValue)
+      ? previousValue
+      : (preferences.primaryId || selected[0].id);
+  }
+
+  function populateCrossingSelects() {
+    populateSelect(elements.observationSelect, elements.observationSelect.value);
+    populateSelect(elements.watchSelect, elements.watchSelect.value);
+    elements.watchStart.disabled = !selectedCrossings().length || Boolean(watchSession);
+    elements.observationForm.querySelectorAll("button[type='submit']").forEach((button) => {
+      button.disabled = !selectedCrossings().length;
+    });
+  }
 
   function movementsFor(crossing, now) {
     const hour = new Date(now);
     hour.setMinutes(0, 0, 0);
-
     return [-1, 0, 1]
       .flatMap((offset) => {
         const start = new Date(hour.getTime() + offset * 60 * 60 * 1000);
         return crossing.minutes.map((minute, index) => {
           const eta = new Date(start.getTime() + minute * 60 * 1000);
           const [destination, direction] = destinations[index % destinations.length];
-          return {
-            id: `demo-${crossing.id}-${eta.toISOString()}`,
-            destination,
-            direction,
-            eta
-          };
+          return { id: `demo-${crossing.id}-${eta.toISOString()}`, destination, direction, eta };
         });
       })
       .filter(({ eta }) => eta >= new Date(now.getTime() - 15 * 60 * 1000))
@@ -115,7 +234,6 @@
         }
         return merged;
       }, []);
-
     const active = intervals.find(({ start, end }) => start <= now && end > now);
     const next = intervals.find(({ start }) => start > now);
 
@@ -131,7 +249,6 @@
         trains: active.trains
       };
     }
-
     if (next && next.start.getTime() - now.getTime() <= 180 * 1000) {
       return {
         state: "CLOSING_SOON",
@@ -142,7 +259,6 @@
         trains: next.trains
       };
     }
-
     return {
       state: "OPEN",
       reason: "No train is currently inside the demonstration closure window.",
@@ -155,34 +271,11 @@
 
   function formatTime(date) {
     if (!date) return "Not predicted";
-    return new Intl.DateTimeFormat("en-GB", {
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit"
-    }).format(date);
+    return new Intl.DateTimeFormat("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" }).format(date);
   }
 
   function formatDuration(seconds) {
     return `${Math.max(1, Math.round(seconds / 60))} min`;
-  }
-
-  function escapeHtml(value) {
-    return String(value)
-      .replaceAll("&", "&amp;")
-      .replaceAll("<", "&lt;")
-      .replaceAll(">", "&gt;")
-      .replaceAll('"', "&quot;")
-      .replaceAll("'", "&#039;");
-  }
-
-  function readObservations() {
-    try {
-      const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || "[]");
-      return Array.isArray(stored) ? stored : [];
-    } catch (_) {
-      window.localStorage.removeItem(STORAGE_KEY);
-      return [];
-    }
   }
 
   function formatObservationTime(value) {
@@ -200,69 +293,184 @@
     }).format(date);
   }
 
+  function readObservations() {
+    const stored = readJson(STORAGE_KEY, []);
+    return Array.isArray(stored) ? stored : [];
+  }
+
+  function writeObservations(observations) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(observations.slice(0, 200)));
+  }
+
   function renderObservations() {
     const observations = readObservations();
-    const count = observations.length;
-    observationCount.hidden = count === 0;
-    observationCount.querySelector("strong").textContent = count;
-    observationHistory.hidden = count === 0;
-    observationRows.innerHTML = observations.slice(0, 10).map((observation) => {
+    elements.observationCount.hidden = observations.length === 0;
+    elements.observationCount.querySelector("strong").textContent = observations.length;
+    elements.observationHistory.hidden = observations.length === 0;
+    elements.observationRows.innerHTML = observations.slice(0, 20).map((observation) => {
       const crossing = crossings.find(({ id }) => id === observation.crossingId);
-      const state = String(observation.state || "Unknown").toLowerCase();
-      const label = state.charAt(0).toUpperCase() + state.slice(1);
+      const syncLabel = observation.syncedAt
+        ? '<span class="crossing-observation-sync crossing-observation-sync--saved">Central copy saved</span>'
+        : observation.syncEligible
+          ? '<span class="crossing-observation-sync">Central sync pending</span>'
+          : '<span class="crossing-observation-sync">Device only</span>';
       const note = observation.note
         ? `<span class="crossing-observation-note">${escapeHtml(observation.note)}</span>`
         : "";
       return `<li>
-        <strong>${escapeHtml(crossing?.name || observation.crossingId || "Crossing")} · ${escapeHtml(label)}</strong>
+        <strong>${escapeHtml(crossing?.name || observation.crossingId || "Crossing")} · ${escapeHtml(observationLabels[observation.state] || observation.state || "Unknown")}</strong>
         <time datetime="${escapeHtml(observation.observedAt || "")}">${escapeHtml(formatObservationTime(observation.observedAt))}</time>
-        ${note}
+        ${note}${syncLabel}
       </li>`;
     }).join("");
   }
 
+  function makeId(prefix) {
+    const value = window.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+    return `${prefix}-${value}`;
+  }
+
+  function serialisePrediction(crossing, now) {
+    const prediction = predict(crossing, now);
+    return {
+      state: prediction.state,
+      eventAt: prediction.eventAt?.toISOString() || null,
+      waitSeconds: prediction.waitSeconds,
+      demoTrainCount: prediction.trains.length
+    };
+  }
+
+  async function syncObservation(observation) {
+    if (!observation.syncEligible || observation.syncedAt) return false;
+    try {
+      const response = await fetch("/api/level-crossing/observations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(observation)
+      });
+      if (!response.ok) return false;
+      const observations = readObservations();
+      const saved = observations.find(({ id }) => id === observation.id);
+      if (saved) {
+        saved.syncedAt = new Date().toISOString();
+        writeObservations(observations);
+        renderObservations();
+      }
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function syncPendingObservations() {
+    readObservations()
+      .filter(({ syncEligible, syncedAt }) => syncEligible && !syncedAt)
+      .slice(-20)
+      .forEach((observation) => { void syncObservation(observation); });
+  }
+
+  function recordObservation({ crossingId, state, eventKind = "quick", sessionId = "", note = "" }) {
+    const crossing = crossings.find(({ id }) => id === crossingId);
+    if (!crossing || !observationLabels[state]) return null;
+    const now = new Date();
+    const observation = {
+      id: makeId("obs"),
+      crossingId,
+      state,
+      observedAt: now.toISOString(),
+      note: String(note).trim().slice(0, 300),
+      eventKind,
+      sessionId,
+      prediction: serialisePrediction(crossing, now),
+      syncEligible: true
+    };
+    writeObservations([observation, ...readObservations()]);
+    renderObservations();
+    void syncObservation(observation);
+    return observation;
+  }
+
+  function renderPredictions() {
+    const now = new Date();
+    const selected = selectedCrossings();
+    const predictions = selected.map((crossing) => ({ crossing, prediction: predict(crossing, now) }));
+    const primary = predictions.find(({ crossing }) => crossing.id === preferences.primaryId);
+
+    if (!primary) {
+      elements.routeAdvice.innerHTML = '<p class="crossing-eyebrow">Best route into town</p><h2>Select a crossing</h2><p>Choose at least one level crossing above to restore route advice.</p>';
+      elements.crossingGrid.innerHTML = '<p class="crossing-grid-empty">No crossings selected.</p>';
+      elements.lastUpdated.textContent = `Updated ${formatTime(now)}`;
+      return;
+    }
+
+    const viaCrossing = primary.crossing.baselineDriveSeconds + primary.prediction.waitSeconds;
+    const viaA27 = 690;
+    const useCrossing = viaCrossing <= viaA27;
+    const saving = Math.abs(viaCrossing - viaA27);
+    elements.routeAdvice.innerHTML = `
+      <p class="crossing-eyebrow">Best route into town · demo estimate</p>
+      <h2>${useCrossing ? `Turn towards ${escapeHtml(primary.crossing.name)}` : "Take the A27"}</h2>
+      <p>${useCrossing ? "The selected crossing route is currently estimated to be quicker." : "The demonstration barrier wait makes the A27 quicker."} <strong>Estimated saving: ${formatDuration(saving)}.</strong></p>
+      <div class="crossing-route-comparison">
+        <span>${escapeHtml(primary.crossing.name)}: ${formatDuration(viaCrossing)}</span>
+        <span>A27: ${formatDuration(viaA27)}</span>
+        <span>Road data: baseline</span>
+      </div>`;
+
+    elements.crossingGrid.innerHTML = predictions.map(({ crossing, prediction }) => {
+      const [label, statusClass] = stateDetails[prediction.state];
+      const nextTrain = prediction.trains[0]
+        ? `<span>Demo train: ${escapeHtml(prediction.trains[0].destination)} · ${escapeHtml(prediction.trains[0].direction)}</span>`
+        : "";
+      return `<article class="crossing-card${crossing.id === preferences.primaryId ? " crossing-card--primary" : ""}">
+        <h3>${escapeHtml(crossing.name)}</h3>
+        ${crossing.id === preferences.primaryId ? '<span class="crossing-primary-tag">Primary route crossing</span>' : ""}
+        <p class="crossing-type">${escapeHtml(crossing.type)}<br><span>///${escapeHtml(crossing.what3words)}</span></p>
+        <span class="crossing-status ${statusClass}">${label}</span>
+        <p class="crossing-prediction-reason">${escapeHtml(prediction.reason)}</p>
+        <div class="crossing-prediction-meta">
+          <span>${escapeHtml(prediction.eventLabel)}: <strong>${formatTime(prediction.eventAt)}</strong></span>
+          <span>Confidence: demonstration</span>${nextTrain}
+        </div>
+      </article>`;
+    }).join("");
+    elements.lastUpdated.textContent = `Updated ${formatTime(now)}`;
+  }
+
   function formatFeedTime(value) {
-    if (!value) return "Waiting";
-    return formatTime(new Date(value));
+    return value ? formatTime(new Date(value)) : "Waiting";
   }
 
   function renderFeedStatus(feed) {
-    feedArea.textContent = feed.area || "CH";
-    feedFrames.textContent = String(feed.frameCount || 0);
-    feedCount.textContent = String(feed.messageCount || 0);
-    feedUpdated.textContent = formatFeedTime(feed.lastMessageAt);
-    feedStatus.className = "crossing-feed-status";
-
+    elements.feedArea.textContent = feed.area || "CH";
+    elements.feedFrames.textContent = String(feed.frameCount || 0);
+    elements.feedCount.textContent = String(feed.messageCount || 0);
+    elements.feedUpdated.textContent = formatFeedTime(feed.lastMessageAt);
+    elements.feedStatus.className = "crossing-feed-status";
     if (feed.status === "connected") {
-      feedStatus.textContent = "Connected";
-      feedStatus.classList.add("crossing-feed-status--connected");
-      modeBadge.textContent = "Live feed · calibrating";
-      feedCopy.textContent = feed.messageCount
-        ? "Receiving Chichester signalling messages. Compare these movements with the physical barriers to identify the correct berths."
+      elements.feedStatus.textContent = "Connected";
+      elements.feedStatus.classList.add("crossing-feed-status--connected");
+      elements.modeBadge.textContent = "Live feed · calibrating";
+      elements.feedCopy.textContent = feed.messageCount
+        ? "Receiving Chichester signalling messages. Field observations can now be compared with nearby berth movements."
         : "Connected to Network Rail and waiting for the next Chichester signalling message.";
     } else if (feed.status === "not_configured") {
-      feedStatus.textContent = "Not configured";
-      feedStatus.classList.add("crossing-feed-status--error");
-      modeBadge.textContent = "Simulation mode";
-      feedCopy.textContent = "The server cannot see the Network Rail username and password environment variables.";
+      elements.feedStatus.textContent = "Not configured";
+      elements.feedStatus.classList.add("crossing-feed-status--error");
+      elements.modeBadge.textContent = "Simulation mode";
+      elements.feedCopy.textContent = "The server cannot see the Network Rail username and password environment variables.";
     } else {
-      feedStatus.textContent = "Connecting";
-      modeBadge.textContent = "Simulation · connecting";
-      feedCopy.textContent = feed.lastError
+      elements.feedStatus.textContent = "Connecting";
+      elements.modeBadge.textContent = "Simulation · connecting";
+      elements.feedCopy.textContent = feed.lastError
         ? `The live connection is retrying (${feed.lastError}). Simulation remains available.`
-        : "Opening the secure Network Rail TD connection. Simulation remains available while it starts.";
+        : "Opening the Network Rail TD connection. Simulation remains available while it starts.";
     }
-
     const events = Array.isArray(feed.recentEvents) ? feed.recentEvents : [];
-    feedEvents.hidden = events.length === 0;
-    feedEventRows.innerHTML = events.map((event) => {
+    elements.feedEvents.hidden = events.length === 0;
+    elements.feedEventRows.innerHTML = events.map((event) => {
       const movement = [event.from, event.to].filter(Boolean).join(" → ") || "Signal update";
-      return `<tr>
-        <td>${escapeHtml(formatFeedTime(event.receivedAt))}</td>
-        <td>${escapeHtml(event.type || "")}</td>
-        <td>${escapeHtml(movement)}</td>
-        <td>${escapeHtml(event.descriptor || "—")}</td>
-      </tr>`;
+      return `<tr><td>${escapeHtml(formatFeedTime(event.receivedAt))}</td><td>${escapeHtml(event.type || "")}</td><td>${escapeHtml(movement)}</td><td>${escapeHtml(event.descriptor || "—")}</td></tr>`;
     }).join("");
   }
 
@@ -276,82 +484,105 @@
     }
   }
 
-  function render() {
-    const now = new Date();
-    const predictions = crossings.map((crossing) => ({ crossing, prediction: predict(crossing, now) }));
-    const primary = predictions.find(({ crossing }) => crossing.primary);
-    const viaWhyke = primary.crossing.baselineDriveSeconds + primary.prediction.waitSeconds;
-    const viaA27 = 690;
-    const useWhyke = viaWhyke <= viaA27;
-    const saving = Math.abs(viaWhyke - viaA27);
-
-    routeAdvice.innerHTML = `
-      <p class="crossing-eyebrow">Best route into town</p>
-      <h2>${useWhyke ? "Turn towards Whyke Road" : "Take the A27"}</h2>
-      <p>
-        ${useWhyke
-          ? "The crossing route is currently estimated to be quicker."
-          : "The predicted barrier wait makes the A27 quicker."}
-        <strong>Estimated saving: ${formatDuration(saving)}.</strong>
-      </p>
-      <div class="crossing-route-comparison">
-        <span>Whyke Road: ${formatDuration(viaWhyke)}</span>
-        <span>A27: ${formatDuration(viaA27)}</span>
-        <span>Road data: baseline</span>
-      </div>`;
-
-    crossingGrid.innerHTML = predictions.map(({ crossing, prediction }) => {
-      const [label, statusClass] = stateDetails[prediction.state];
-      const nextTrain = prediction.trains[0]
-        ? `<span>Demo train: ${escapeHtml(prediction.trains[0].destination)} · ${escapeHtml(prediction.trains[0].direction)}</span>`
-        : "";
-      return `
-        <article class="crossing-card${crossing.primary ? " crossing-card--primary" : ""}">
-          <h3>${escapeHtml(crossing.name)}</h3>
-          ${crossing.primary ? '<span class="crossing-primary-tag">Closest to home</span>' : ""}
-          <p class="crossing-type">${escapeHtml(crossing.type)}</p>
-          <span class="crossing-status ${statusClass}">${label}</span>
-          <p class="crossing-prediction-reason">${escapeHtml(prediction.reason)}</p>
-          <div class="crossing-prediction-meta">
-            <span>${escapeHtml(prediction.eventLabel)}: <strong>${formatTime(prediction.eventAt)}</strong></span>
-            <span>Confidence: demonstration</span>
-            ${nextTrain}
-          </div>
-        </article>`;
-    }).join("");
-
-    lastUpdated.textContent = `Updated ${formatTime(now)}`;
+  function updateWatchElapsed() {
+    if (!watchSession) return;
+    const seconds = Math.max(0, Math.floor((Date.now() - watchSession.startedAt) / 1000));
+    elements.watchElapsed.textContent = `${String(Math.floor(seconds / 60)).padStart(2, "0")}:${String(seconds % 60).padStart(2, "0")}`;
   }
 
-  crossings.forEach((crossing) => {
-    observationSelect.add(new Option(crossing.name, crossing.id, false, crossing.primary));
+  elements.selectionToggle.addEventListener("click", () => {
+    const opening = elements.selectionControls.hidden;
+    elements.selectionControls.hidden = !opening;
+    elements.selectionToggle.setAttribute("aria-expanded", String(opening));
+    elements.selectionToggle.textContent = opening ? "Done" : "Change selection";
   });
 
-  refreshButton.addEventListener("click", render);
+  elements.selectionOptions.addEventListener("change", (event) => {
+    const selectId = event.target.dataset.crossingSelect;
+    const primaryId = event.target.dataset.crossingPrimary;
+    if (selectId) {
+      preferences.selectedIds = event.target.checked
+        ? [...new Set([...preferences.selectedIds, selectId])]
+        : preferences.selectedIds.filter((id) => id !== selectId);
+    }
+    if (primaryId && event.target.checked) preferences.primaryId = primaryId;
+    ensurePrimary();
+    savePreferences();
+    renderSelection();
+    renderPredictions();
+  });
 
-  observationForm.addEventListener("submit", (event) => {
+  elements.refreshButton.addEventListener("click", () => {
+    renderPredictions();
+    void loadFeedStatus();
+    syncPendingObservations();
+  });
+
+  elements.observationForm.addEventListener("submit", (event) => {
     event.preventDefault();
     const submitter = event.submitter;
-    if (!submitter?.value) return;
-
-    const crossing = crossings.find(({ id }) => id === observationSelect.value);
-    const observation = {
-      id: `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
-      crossingId: observationSelect.value,
+    if (!submitter?.value || !elements.observationSelect.value) return;
+    const observation = recordObservation({
+      crossingId: elements.observationSelect.value,
       state: submitter.value,
-      observedAt: new Date().toISOString(),
-      note: observationNote.value.trim().slice(0, 300)
-    };
-    const observations = [observation, ...readObservations()].slice(0, 100);
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(observations));
-    observationNote.value = "";
-    observationResult.textContent = `${submitter.textContent} recorded for ${crossing?.name || "the crossing"} at ${formatObservationTime(observation.observedAt)}.`;
-    renderObservations();
+      note: elements.observationNote.value
+    });
+    const crossing = crossings.find(({ id }) => id === observation.crossingId);
+    elements.observationNote.value = "";
+    elements.observationResult.textContent = `${observationLabels[observation.state]} recorded for ${crossing.name} at ${formatObservationTime(observation.observedAt)}.`;
   });
 
+  elements.watchStart.addEventListener("click", () => {
+    const crossing = crossings.find(({ id }) => id === elements.watchSelect.value);
+    if (!crossing) return;
+    watchSession = {
+      id: makeId("session"),
+      crossingId: crossing.id,
+      startedAt: Date.now(),
+      trainCount: 0
+    };
+    elements.watchActive.hidden = false;
+    elements.watchStart.disabled = true;
+    elements.watchSelect.disabled = true;
+    elements.watchName.textContent = `Watching ${crossing.name}`;
+    elements.watchTrainCount.textContent = "0";
+    elements.watchResult.textContent = "Session started. Tap only when safely stationary.";
+    updateWatchElapsed();
+  });
+
+  elements.watchActive.addEventListener("click", (event) => {
+    const state = event.target.dataset.watchState;
+    if (!watchSession || !state) return;
+    const observation = recordObservation({
+      crossingId: watchSession.crossingId,
+      state,
+      eventKind: "watch",
+      sessionId: watchSession.id
+    });
+    if (state === "TRAIN_PASSED") {
+      watchSession.trainCount += 1;
+      elements.watchTrainCount.textContent = String(watchSession.trainCount);
+    }
+    elements.watchResult.textContent = `${observationLabels[state]} recorded at ${formatObservationTime(observation.observedAt)}.`;
+  });
+
+  elements.watchFinish.addEventListener("click", () => {
+    if (!watchSession) return;
+    const crossing = crossings.find(({ id }) => id === watchSession.crossingId);
+    const count = watchSession.trainCount;
+    watchSession = null;
+    elements.watchActive.hidden = true;
+    elements.watchSelect.disabled = false;
+    elements.watchStart.disabled = !selectedCrossings().length;
+    elements.observationResult.textContent = `${crossing.name} watch session finished with ${count} train${count === 1 ? "" : "s"} recorded.`;
+  });
+
+  renderSelection();
   renderObservations();
-  render();
-  loadFeedStatus();
-  window.setInterval(render, 30000);
+  renderPredictions();
+  void loadFeedStatus();
+  syncPendingObservations();
+  window.setInterval(renderPredictions, 30000);
   window.setInterval(loadFeedStatus, 10000);
+  window.setInterval(updateWatchElapsed, 1000);
 })();

--- a/supabase/level_crossing_observations.sql
+++ b/supabase/level_crossing_observations.sql
@@ -1,0 +1,27 @@
+-- Anonymous field observations used to calibrate level-crossing TD berths.
+-- Safe to run in Supabase SQL Editor. No public read or write policy is created.
+
+create table if not exists public.level_crossing_observations (
+  id text primary key,
+  crossing_id text not null check (crossing_id in ('whyke-road', 'basin-road', 'stockbridge-road')),
+  crossing_name text not null,
+  what3words text not null,
+  state text not null check (state in ('OPEN', 'CLOSING', 'CLOSED', 'OPENING', 'TRAIN_PASSED')),
+  event_kind text not null default 'quick' check (event_kind in ('quick', 'watch')),
+  observed_at timestamptz not null,
+  received_at timestamptz not null default now(),
+  session_id text,
+  note text check (char_length(note) <= 300),
+  client_prediction jsonb not null default '{}'::jsonb,
+  td_snapshot jsonb not null default '{}'::jsonb
+);
+
+create index if not exists level_crossing_observations_crossing_time_idx
+  on public.level_crossing_observations(crossing_id, observed_at desc);
+create index if not exists level_crossing_observations_session_idx
+  on public.level_crossing_observations(session_id, observed_at)
+  where session_id is not null;
+
+alter table public.level_crossing_observations enable row level security;
+grant usage on schema public to service_role;
+grant select, insert, update on table public.level_crossing_observations to service_role;

--- a/templates/level-crossing.html
+++ b/templates/level-crossing.html
@@ -4,7 +4,7 @@
 
 {% block head_extra %}
   <meta name="description" content="Predicted status for Whyke Road, Stockbridge Road and Basin Road level crossings, with route guidance into Chichester.">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/level-crossing.css') }}?v=2">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/level-crossing.css') }}?v=3">
 {% endblock %}
 
 {% block body_class %} level-crossing-page{% endblock %}
@@ -18,6 +18,23 @@
     </div>
     <span class="crossing-mode-badge">Simulation mode</span>
   </header>
+
+  <section class="crossing-selection-panel" aria-labelledby="crossing-selection-title">
+    <div class="crossing-selection-heading">
+      <div>
+        <p class="crossing-eyebrow">Your local view</p>
+        <h2 id="crossing-selection-title">Selected level crossings</h2>
+        <p id="crossing-selection-summary">Choose the crossings you want to monitor.</p>
+      </div>
+      <button id="crossing-selection-toggle" class="crossing-button crossing-button--secondary" type="button" aria-expanded="false" aria-controls="crossing-selection-controls">Change selection</button>
+    </div>
+    <div id="crossing-selection-chips" class="crossing-selection-chips" aria-live="polite"></div>
+    <div id="crossing-selection-controls" class="crossing-selection-controls" hidden>
+      <h3>Chichester</h3>
+      <p>Select crossings to show, then choose one as the primary crossing for route advice.</p>
+      <div id="crossing-selection-options"></div>
+    </div>
+  </section>
 
   <section id="crossing-route-advice" class="crossing-route-advice" aria-live="polite">
     <p class="crossing-eyebrow">Best route into town</p>
@@ -69,9 +86,9 @@
       <p class="crossing-eyebrow">Calibration</p>
       <h2>What can you see?</h2>
       <p>
-        Log the physical barrier state when you happen to observe it. Records are timestamped and
-        stay on this device for now; they help us calibrate the live feed without collecting your
-        location or identity.
+        Log the physical barrier state when you happen to observe it. Records save immediately on
+        this device, then sync anonymously with the surrounding signalling messages when central
+        storage is available.
       </p>
       <div id="crossing-observation-count" class="crossing-observation-count" hidden>
         <strong>0</strong>
@@ -98,6 +115,33 @@
       <p id="crossing-observation-result" class="crossing-form-result" aria-live="polite"></p>
     </form>
 
+    <section class="crossing-watch-panel" aria-labelledby="crossing-watch-title">
+      <div class="crossing-watch-intro">
+        <p class="crossing-eyebrow">Optional field session</p>
+        <h3 id="crossing-watch-title">Watch one complete barrier cycle</h3>
+        <p>Start only when safely parked or standing away from the road. Each tap is timestamped automatically.</p>
+        <label for="crossing-watch-select">Crossing</label>
+        <select id="crossing-watch-select"></select>
+        <button id="crossing-watch-start" class="crossing-button crossing-watch-start" type="button">Start watch session</button>
+      </div>
+      <div id="crossing-watch-active" class="crossing-watch-active" hidden>
+        <div class="crossing-watch-status">
+          <span id="crossing-watch-name">Watching</span>
+          <strong id="crossing-watch-elapsed">00:00</strong>
+          <span><strong id="crossing-watch-train-count">0</strong> trains recorded</span>
+        </div>
+        <div class="crossing-watch-buttons">
+          <button type="button" data-watch-state="CLOSING" class="crossing-button crossing-state-warning">Closing</button>
+          <button type="button" data-watch-state="CLOSED" class="crossing-button crossing-state-closed">Closed</button>
+          <button type="button" data-watch-state="TRAIN_PASSED" class="crossing-button crossing-watch-train">Train passed</button>
+          <button type="button" data-watch-state="OPENING" class="crossing-button crossing-state-opening">Opening</button>
+          <button type="button" data-watch-state="OPEN" class="crossing-button crossing-state-open">Open</button>
+        </div>
+        <button id="crossing-watch-finish" class="crossing-button crossing-button--secondary" type="button">Finish session</button>
+        <p id="crossing-watch-result" class="crossing-form-result" aria-live="polite"></p>
+      </div>
+    </section>
+
     <details id="crossing-observation-history" class="crossing-observation-history" hidden>
       <summary>Recent observations on this device</summary>
       <ol id="crossing-observation-rows"></ol>
@@ -118,5 +162,5 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="{{ url_for('static', filename='js/level-crossing.js') }}?v=2"></script>
+  <script src="{{ url_for('static', filename='js/level-crossing.js') }}?v=3"></script>
 {% endblock %}

--- a/tests/test_level_crossing.py
+++ b/tests/test_level_crossing.py
@@ -1,8 +1,14 @@
 import json
 import unittest
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from app import app
+from services.level_crossing.observations import (
+    LevelCrossingObservationStore,
+    ObservationRateLimiter,
+    ObservationValidationError,
+)
 from services.level_crossing.td_feed import TrainDescriberFeed
 
 
@@ -20,6 +26,8 @@ class LevelCrossingPageTests(unittest.TestCase):
         self.assertIn(b"Simulation mode", response.data)
         self.assertIn(b"Route-planning prediction only", response.data)
         self.assertIn(b"Recent observations on this device", response.data)
+        self.assertIn(b"Selected level crossings", response.data)
+        self.assertIn(b"Start watch session", response.data)
         css_response = self.client.get("/static/css/level-crossing.css")
         js_response = self.client.get("/static/js/level-crossing.js")
         self.assertEqual(css_response.status_code, 200)
@@ -46,6 +54,32 @@ class LevelCrossingPageTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json()["status"], "not_configured")
         self.assertNotIn(b"password", response.data.lower())
+
+    @patch("app.observation_rate_limiter.allow", return_value=True)
+    @patch("app.observation_store.save")
+    @patch("app.td_feed.snapshot", return_value={"area": "CH", "recentEvents": []})
+    @patch("app.td_feed.start", return_value=True)
+    def test_observation_endpoint_stores_td_context(self, _start, _snapshot, save, _allow):
+        save.return_value = {"id": "obs-12345678"}
+        payload = {
+            "id": "obs-12345678",
+            "crossingId": "whyke-road",
+            "state": "OPEN",
+            "observedAt": datetime.now(timezone.utc).isoformat(),
+            "eventKind": "quick",
+        }
+
+        response = self.client.post("/api/level-crossing/observations", json=payload)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.get_json(), {"saved": True, "id": "obs-12345678"})
+        save.assert_called_once_with(payload, {"area": "CH", "recentEvents": []})
+
+    @patch("app.observation_rate_limiter.allow", return_value=False)
+    def test_observation_endpoint_is_rate_limited(self, _allow):
+        response = self.client.post("/api/level-crossing/observations", json={})
+
+        self.assertEqual(response.status_code, 429)
 
 
 class TrainDescriberFeedTests(unittest.TestCase):
@@ -85,6 +119,74 @@ class TrainDescriberFeedTests(unittest.TestCase):
         error = self.feed.snapshot()["lastError"]
         self.assertNotIn("test@example.com", error)
         self.assertNotIn("not-returned-by-status", error)
+
+
+class FakeSupabaseClient:
+    configured = True
+
+    def __init__(self):
+        self.calls = []
+
+    def request(self, table, method="GET", query=None, payload=None, prefer=None):
+        self.calls.append((table, method, payload, prefer))
+        return [payload]
+
+
+class LevelCrossingObservationTests(unittest.TestCase):
+    def setUp(self):
+        self.client = FakeSupabaseClient()
+        self.store = LevelCrossingObservationStore(client=self.client)
+        self.payload = {
+            "id": "obs-12345678",
+            "crossingId": "whyke-road",
+            "state": "TRAIN_PASSED",
+            "eventKind": "watch",
+            "sessionId": "session-12345678",
+            "observedAt": datetime.now(timezone.utc).isoformat(),
+            "note": "First train",
+            "prediction": {"state": "LIKELY_CLOSED", "demoTrainCount": 3},
+        }
+
+    def test_builds_anonymous_row_with_location_and_td_snapshot(self):
+        saved = self.store.save(
+            self.payload,
+            {
+                "area": "CH",
+                "status": "connected",
+                "lastMessageAt": "2026-07-31T15:25:01+00:00",
+                "messageCount": 44,
+                "recentEvents": [{"type": "CA", "from": "0101", "to": "0102"}],
+                "activeBerths": {"0102": "1A23"},
+                "lastError": "must not be stored",
+            },
+        )
+
+        self.assertEqual(saved["crossing_name"], "Whyke Road")
+        self.assertEqual(saved["what3words"], "awake.mason.melon")
+        self.assertEqual(saved["td_snapshot"]["activeBerths"], {"0102": "1A23"})
+        self.assertNotIn("lastError", saved["td_snapshot"])
+        self.assertNotIn("ip", str(saved).lower())
+        self.assertEqual(self.client.calls[0][0], "level_crossing_observations")
+        self.assertIn("merge-duplicates", self.client.calls[0][3])
+
+    def test_rejects_unknown_crossing_and_old_timestamp(self):
+        self.payload["crossingId"] = "made-up-crossing"
+        with self.assertRaises(ObservationValidationError):
+            self.store.build_row(self.payload, {})
+
+        self.payload["crossingId"] = "whyke-road"
+        self.payload["observedAt"] = (datetime.now(timezone.utc) - timedelta(days=31)).isoformat()
+        with self.assertRaises(ObservationValidationError):
+            self.store.build_row(self.payload, {})
+
+    def test_rate_limiter_allows_burst_then_blocks(self):
+        limiter = ObservationRateLimiter(limit=2, window_seconds=60)
+        now = datetime.now(timezone.utc)
+
+        self.assertTrue(limiter.allow("device", now))
+        self.assertTrue(limiter.allow("device", now))
+        self.assertFalse(limiter.allow("device", now))
+        self.assertTrue(limiter.allow("device", now + timedelta(seconds=61)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- adds a future-ready **Selected level crossings** panel with saved selection and primary-route choice
- includes the three supplied what3words locations and displays only selected crossing cards
- adds a safe, mobile-friendly watch session for Closing, Closed, Train passed, Opening and Open events
- keeps observations locally first, then retries anonymous central sync when available
- captures a sanitised CH TD snapshot and demonstration prediction alongside every new synced observation
- adds validation, idempotent writes, rate limiting and a Supabase migration with service-role-only access

## Weekend testing

The selector, primary crossing, quick observations, watch sessions and local history work immediately after deployment. To enable central copies, run `supabase/level_crossing_observations.sql` once in the existing Supabase SQL Editor.

## Validation

- JavaScript syntax check passed
- crossing-specific suite: 11 tests passed
- full CXMS suite: 119 tests passed
- Python compile and diff checks passed
- blob hashes verified against the local commit before publication