### PR TITLE
Redesign crossing monitor status experience

### DIFF
--- a/static/css/level-crossing.css
+++ b/static/css/level-crossing.css
@@ -1,481 +1,384 @@
-.level-crossing-page .site-main {
-  background: #f2f6f8;
-  color: #102a43;
+:root {
+  color-scheme: light;
+  --ink: #102a38;
+  --muted: #607682;
+  --soft: #edf3f5;
+  --line: #d7e2e6;
+  --surface: #ffffff;
+  --navy: #071d2b;
+  --blue: #176b8c;
+  --blue-soft: #e3f2f7;
+  --green: #08765d;
+  --green-soft: #ddf5ed;
+  --amber: #9a5708;
+  --amber-soft: #fff1d4;
+  --red: #a92d27;
+  --red-soft: #fee8e6;
+  --shadow-sm: 0 8px 24px rgba(13, 39, 51, 0.07);
+  --shadow-lg: 0 24px 70px rgba(4, 29, 43, 0.17);
 }
 
-.level-crossing-page .site-main > .site-shell {
-  width: min(100% - 32px, 1120px);
+* { box-sizing: border-box; }
+
+html { min-height: 100%; background: var(--soft); }
+
+body {
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(89, 174, 199, 0.13), transparent 28rem),
+    linear-gradient(180deg, #f8fbfc 0, var(--soft) 34rem);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
 }
 
-.crossing-monitor {
-  --crossing-ink: #102a43;
-  --crossing-muted: #627d98;
-  --crossing-surface: #ffffff;
-  --crossing-line: #d9e2ec;
-  --crossing-blue: #1261a0;
-  --crossing-green: #147d64;
-  --crossing-amber: #b45309;
-  --crossing-red: #b42318;
-  --crossing-shadow: 0 16px 40px rgba(16, 42, 67, 0.1);
-  padding: 28px 0 18px;
-  color: var(--crossing-ink);
-}
+button,
+input,
+select { font: inherit; }
 
-.crossing-monitor *,
-.crossing-monitor *::before,
-.crossing-monitor *::after {
-  box-sizing: border-box;
-}
+button,
+summary,
+select { -webkit-tap-highlight-color: transparent; }
 
-.crossing-monitor button,
-.crossing-monitor input,
-.crossing-monitor select {
-  font: inherit;
-}
+h1,
+h2,
+h3,
+p { margin-top: 0; }
 
-.crossing-monitor h1,
-.crossing-monitor h2,
-.crossing-monitor h3,
-.crossing-monitor p {
-  margin-top: 0;
-}
+h1,
+h2,
+h3 { letter-spacing: -0.035em; }
 
-.crossing-monitor h1 {
-  margin-bottom: 0;
-  color: var(--crossing-ink);
-  font-size: clamp(1.45rem, 4vw, 2.1rem);
-  letter-spacing: -0.03em;
-}
-
-.crossing-monitor h2 {
-  margin-bottom: 8px;
-  color: var(--crossing-ink);
-  font-size: clamp(1.35rem, 4vw, 2rem);
-  letter-spacing: -0.025em;
-}
-
-.crossing-monitor__header {
+.crossing-app-bar {
+  position: sticky;
+  z-index: 20;
+  top: 0;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: 16px;
-  padding-bottom: 18px;
+  justify-content: space-between;
+  gap: 20px;
+  min-height: 76px;
+  padding: 12px max(20px, calc((100vw - 1180px) / 2));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  background: rgba(7, 29, 43, 0.96);
+  box-shadow: 0 12px 35px rgba(4, 21, 31, 0.2);
+  backdrop-filter: blur(14px);
+}
+
+.crossing-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: #fff;
+  text-decoration: none;
+}
+
+.crossing-brand-mark {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 13px;
+  background: linear-gradient(145deg, #1c7da0, #0d516e);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.crossing-brand-mark svg { width: 31px; height: 31px; fill: none; stroke: #fff; stroke-width: 2.5; stroke-linecap: round; }
+.crossing-brand > span:last-child { display: grid; gap: 1px; }
+.crossing-brand strong { font-size: 1.05rem; letter-spacing: -0.02em; }
+.crossing-brand small { color: #a9c4d1; font-size: 0.7rem; }
+.crossing-app-actions { display: flex; align-items: center; gap: 10px; }
+.crossing-cxms-link { padding: 8px 3px; color: #aac4d0; font-size: 0.76rem; font-weight: 700; text-decoration: none; }
+.crossing-cxms-link:hover { color: #fff; }
+
+.crossing-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 11px;
+  border-radius: 999px;
+  background: rgba(255, 203, 101, 0.14);
+  color: #ffd88b;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+.crossing-mode-badge::before { width: 7px; height: 7px; border-radius: 50%; background: currentColor; content: ""; box-shadow: 0 0 0 4px rgba(255, 216, 139, 0.09); }
+
+.crossing-app-shell {
+  width: min(calc(100% - 32px), 1180px);
+  margin: 0 auto;
+  padding: clamp(24px, 5vw, 54px) 0 30px;
 }
 
 .crossing-eyebrow {
-  margin-bottom: 5px;
-  color: var(--crossing-blue);
-  font-size: 0.74rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
+  display: block;
+  margin-bottom: 6px;
+  color: var(--blue);
+  font-size: 0.69rem;
+  font-weight: 850;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
-.crossing-mode-badge {
-  padding: 8px 12px;
-  border-radius: 999px;
-  background: #fff1d6;
-  color: #8a4b08;
-  font-size: 0.76rem;
-  font-weight: 800;
-}
-
 .crossing-selection-panel {
-  margin: 8px 0 22px;
-  padding: clamp(18px, 3vw, 26px);
-  border: 1px solid var(--crossing-line);
-  border-radius: 18px;
-  background: var(--crossing-surface);
-  box-shadow: 0 8px 24px rgba(16, 42, 67, 0.06);
+  padding: clamp(20px, 4vw, 32px);
+  border: 1px solid rgba(215, 226, 230, 0.9);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: var(--shadow-sm);
 }
 
 .crossing-selection-heading {
   display: flex;
   align-items: start;
   justify-content: space-between;
-  gap: 20px;
+  gap: 24px;
 }
-.crossing-selection-heading h2 { margin-bottom: 4px; font-size: clamp(1.2rem, 3vw, 1.55rem); }
-.crossing-selection-heading p { margin-bottom: 0; color: var(--crossing-muted); }
-.crossing-selection-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
-.crossing-selection-chip,
-.crossing-selection-empty {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 7px 10px;
-  border-radius: 999px;
-  background: #edf2f7;
-  color: #334e68;
-  font-size: 0.8rem;
-  font-weight: 750;
+.crossing-selection-heading h1 { margin-bottom: 6px; font-size: clamp(1.55rem, 4vw, 2.25rem); }
+.crossing-selection-heading p { margin-bottom: 0; color: var(--muted); font-size: 0.92rem; line-height: 1.5; }
+
+.crossing-button {
+  min-height: 46px;
+  padding: 11px 16px;
+  border: 0;
+  border-radius: 12px;
+  font-weight: 800;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
 }
-.crossing-selection-chip--primary { background: #e4f2fb; color: #175b89; }
-.crossing-selection-controls { margin-top: 18px; padding-top: 18px; border-top: 1px solid var(--crossing-line); }
-.crossing-selection-controls h3 { margin: 0 0 4px; }
-.crossing-selection-controls > p { color: var(--crossing-muted); font-size: 0.84rem; }
-.crossing-selection-option {
+.crossing-button:hover { transform: translateY(-1px); box-shadow: 0 7px 18px rgba(13, 39, 51, 0.1); }
+.crossing-button:active { transform: translateY(0); }
+.crossing-button:disabled { opacity: 0.48; cursor: not-allowed; transform: none; box-shadow: none; }
+.crossing-button--quiet { border: 1px solid var(--line); background: #fff; color: var(--ink); }
+
+.crossing-button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+summary:focus-visible,
+a:focus-visible { outline: 3px solid #69b9d5; outline-offset: 3px; }
+
+.crossing-selection-chips {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 230px), 1fr));
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.crossing-selection-chip {
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 12px;
-  padding: 10px 0;
-  border-bottom: 1px solid #edf2f7;
+  min-height: 62px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 15px;
+  background: #f9fbfc;
 }
+.crossing-selection-chip--primary { border-color: #89bfd1; background: #f2fafc; box-shadow: inset 3px 0 var(--blue); }
+.crossing-selection-chip-name { display: flex; align-items: center; gap: 6px; color: var(--ink); font-size: 0.88rem; font-weight: 850; }
+.crossing-selection-chip-name > span { color: #e0a01c; }
+.crossing-selection-chip-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 8px;
+  border-radius: 999px;
+  font-size: 0.69rem;
+  font-weight: 850;
+  white-space: nowrap;
+}
+.crossing-selection-chip-state::before { width: 8px; height: 8px; border-radius: 50%; background: currentColor; content: ""; }
+.crossing-selection-chip-state--open { background: var(--green-soft); color: var(--green); }
+.crossing-selection-chip-state--closing { background: var(--amber-soft); color: var(--amber); }
+.crossing-selection-chip-state--closed { background: var(--red-soft); color: var(--red); }
+.crossing-selection-empty { padding: 16px; border: 1px dashed #b8c9d0; border-radius: 14px; color: var(--muted); text-align: center; }
+
+.crossing-selection-controls {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.45fr) minmax(0, 1fr);
+  gap: 28px;
+  margin-top: 24px;
+  padding-top: 22px;
+  border-top: 1px solid var(--line);
+}
+.crossing-selection-controls[hidden] { display: none; }
+.crossing-selection-controls h2 { margin-bottom: 5px; font-size: 1.2rem; }
+.crossing-selection-controls p { margin-bottom: 0; color: var(--muted); font-size: 0.82rem; line-height: 1.5; }
+.crossing-selection-option { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 10px 0; border-bottom: 1px solid #e9eff1; }
+.crossing-selection-option:first-child { padding-top: 0; }
 .crossing-selection-option label { display: flex; align-items: center; gap: 10px; cursor: pointer; }
-.crossing-selection-option input { width: 18px; height: 18px; accent-color: var(--crossing-blue); }
+.crossing-selection-option input { width: 19px; height: 19px; accent-color: var(--blue); }
 .crossing-selection-option span { display: grid; gap: 2px; }
-.crossing-selection-option small { color: var(--crossing-muted); }
-.crossing-primary-choice { color: #245b87; font-size: 0.8rem; font-weight: 750; }
+.crossing-selection-option small { color: var(--muted); }
+.crossing-primary-choice { color: var(--blue); font-size: 0.78rem; font-weight: 800; }
 
 .crossing-route-advice {
   position: relative;
   overflow: hidden;
-  margin: 12px 0 34px;
-  padding: clamp(24px, 5vw, 48px);
-  border-radius: 24px;
-  background: linear-gradient(135deg, #102a43, #174f78);
-  color: #ffffff;
-  box-shadow: var(--crossing-shadow);
+  margin: 18px 0 46px;
+  min-height: 310px;
+  padding: clamp(30px, 6vw, 62px);
+  border-radius: 28px;
+  background:
+    radial-gradient(circle at 88% 15%, rgba(72, 176, 197, 0.22), transparent 18rem),
+    linear-gradient(135deg, #071d2b, #0b3549 64%, #11526b);
+  color: #fff;
+  box-shadow: var(--shadow-lg);
 }
+.crossing-route-advice::before,
+.crossing-route-advice::after { position: absolute; border: 1px solid rgba(255, 255, 255, 0.11); border-radius: 50%; content: ""; }
+.crossing-route-advice::before { right: -90px; bottom: -170px; width: 390px; height: 390px; }
+.crossing-route-advice::after { right: 28px; bottom: -115px; width: 250px; height: 250px; }
+.crossing-route-advice .crossing-eyebrow { position: relative; z-index: 1; color: #8fd4e8; }
+.crossing-route-advice h2 { position: relative; z-index: 1; max-width: 820px; margin-bottom: 18px; color: #fff; font-size: clamp(2.4rem, 8vw, 5.2rem); line-height: 0.95; }
+.crossing-route-advice p { position: relative; z-index: 1; max-width: 700px; color: #d4e5eb; font-size: clamp(0.95rem, 2vw, 1.08rem); line-height: 1.55; }
+.crossing-route-advice p strong { color: #fff; }
+.crossing-route-comparison { position: relative; z-index: 1; display: flex; flex-wrap: wrap; gap: 8px; margin-top: 26px; }
+.crossing-route-comparison span { padding: 8px 11px; border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 999px; background: rgba(255, 255, 255, 0.07); color: #d7e9ef; font-size: 0.76rem; font-weight: 750; }
 
-.crossing-route-advice::after {
-  position: absolute;
-  right: -70px;
-  bottom: -110px;
-  width: 270px;
-  height: 270px;
-  border: 48px solid rgba(255, 255, 255, 0.07);
-  border-radius: 50%;
-  content: "";
-}
-
-.crossing-route-advice .crossing-eyebrow { color: #9fd8ff; }
-.crossing-route-advice h2 {
-  position: relative;
-  z-index: 1;
-  max-width: 760px;
-  color: #ffffff;
-  font-size: clamp(2rem, 8vw, 4.4rem);
-  line-height: 0.98;
-}
-
-.crossing-route-advice p {
-  position: relative;
-  z-index: 1;
-  max-width: 760px;
-  line-height: 1.55;
-}
-
-.crossing-route-comparison {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 22px;
-  margin-top: 20px;
-  color: #d9efff;
-}
-
-.crossing-section-heading {
-  display: flex;
-  justify-content: space-between;
-  align-items: end;
-  gap: 16px;
-  margin-bottom: 14px;
-}
-
-.crossing-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
-  gap: 16px;
-}
-.crossing-grid-empty { grid-column: 1 / -1; padding: 22px; border-radius: 14px; background: #ffffff; color: var(--crossing-muted); }
-
-.crossing-card {
-  padding: 22px;
-  border: 1px solid var(--crossing-line);
-  border-radius: 18px;
-  background: var(--crossing-surface);
-  box-shadow: 0 8px 24px rgba(16, 42, 67, 0.06);
-}
-
-.crossing-card--primary {
-  border-color: #8dc8ef;
-  box-shadow: 0 8px 24px rgba(18, 97, 160, 0.1);
-}
-
-.crossing-card h3 {
-  margin: 0 0 4px;
-  color: var(--crossing-ink);
-  font-size: 1.22rem;
-}
-
-.crossing-type {
-  min-height: 42px;
-  color: var(--crossing-muted);
-  font-size: 0.82rem;
-}
-
-.crossing-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin: 14px 0;
-  padding: 8px 10px;
-  border-radius: 9px;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
-}
-
-.crossing-status::before {
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: currentColor;
-  content: "";
-}
-
-.crossing-status--open { color: var(--crossing-green); background: #e6f6f0; }
-.crossing-status--closing { color: var(--crossing-amber); background: #fff4dc; }
-.crossing-status--closed { color: var(--crossing-red); background: #feeceb; }
-.crossing-status--unknown { color: var(--crossing-muted); background: #edf2f7; }
-
-.crossing-prediction-reason {
-  min-height: 54px;
-  color: #334e68;
-  line-height: 1.45;
-}
-
-.crossing-prediction-meta {
-  display: grid;
-  gap: 5px;
-  padding-top: 14px;
-  border-top: 1px solid var(--crossing-line);
-  color: var(--crossing-muted);
-  font-size: 0.82rem;
-}
-
-.crossing-primary-tag {
-  color: var(--crossing-blue);
-  font-size: 0.72rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-
-.crossing-button {
-  min-height: 42px;
-  padding: 10px 15px;
-  border: 0;
-  border-radius: 10px;
-  font-weight: 750;
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.crossing-button:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 5px 12px rgba(16, 42, 67, 0.1);
-}
-.crossing-button:disabled { opacity: 0.5; cursor: not-allowed; transform: none; box-shadow: none; }
-
-.crossing-button:focus-visible,
-.crossing-monitor input:focus-visible,
-.crossing-monitor select:focus-visible {
-  outline: 3px solid #78c7f7;
-  outline-offset: 2px;
-}
-
-.crossing-button--secondary {
-  border: 1px solid var(--crossing-line);
-  background: #ffffff;
-  color: var(--crossing-ink);
-}
-
-.crossing-feed-panel {
-  display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
-  gap: 24px 34px;
-  margin: 38px 0 24px;
-  padding: clamp(22px, 4vw, 34px);
-  border: 1px solid #b9d9ee;
-  border-radius: 20px;
-  background: #f8fcff;
-  box-shadow: 0 10px 30px rgba(18, 97, 160, 0.08);
-}
-
-.crossing-feed-panel p { color: var(--crossing-muted); line-height: 1.55; }
-.crossing-feed-summary { align-self: start; padding: 18px; border-radius: 14px; background: #ffffff; }
-.crossing-feed-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 14px;
-  padding: 7px 10px;
-  border-radius: 999px;
-  background: #fff1d6;
-  color: #8a4b08;
-  font-size: 0.76rem;
-  font-weight: 800;
-}
-.crossing-feed-status::before { width: 8px; height: 8px; border-radius: 50%; background: currentColor; content: ""; }
-.crossing-feed-status--connected { background: #e6f6f0; color: var(--crossing-green); }
-.crossing-feed-status--error { background: #feeceb; color: var(--crossing-red); }
-.crossing-feed-summary dl { display: grid; gap: 9px; margin: 0; }
-.crossing-feed-summary dl div { display: flex; justify-content: space-between; gap: 18px; }
-.crossing-feed-summary dt { color: var(--crossing-muted); font-size: 0.8rem; }
-.crossing-feed-summary dd { margin: 0; color: var(--crossing-ink); font-size: 0.82rem; font-weight: 750; text-align: right; }
-.crossing-feed-events { grid-column: 1 / -1; }
-.crossing-feed-events summary { color: #245b87; font-weight: 750; cursor: pointer; }
-.crossing-feed-table-wrap { overflow-x: auto; margin-top: 12px; }
-.crossing-feed-events table { width: 100%; border-collapse: collapse; background: #ffffff; font-size: 0.78rem; }
-.crossing-feed-events th,
-.crossing-feed-events td { padding: 9px 10px; border-bottom: 1px solid var(--crossing-line); color: #334e68; text-align: left; white-space: nowrap; }
-.crossing-feed-events th { color: var(--crossing-muted); font-size: 0.7rem; letter-spacing: 0.04em; text-transform: uppercase; }
-.crossing-feed-note { grid-column: 1 / -1; margin: -4px 0 0; font-size: 0.78rem; }
+.crossing-local-section { margin-bottom: 46px; }
+.crossing-section-heading { display: flex; align-items: end; justify-content: space-between; gap: 20px; margin-bottom: 16px; }
+.crossing-section-heading h2 { margin-bottom: 0; font-size: clamp(1.55rem, 4vw, 2.25rem); }
+.crossing-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr)); gap: 14px; }
+.crossing-grid-empty { grid-column: 1 / -1; padding: 24px; border: 1px dashed #b8c9d0; border-radius: 16px; color: var(--muted); text-align: center; }
+.crossing-card { position: relative; overflow: hidden; padding: 24px; border: 1px solid var(--line); border-radius: 20px; background: rgba(255, 255, 255, 0.96); box-shadow: var(--shadow-sm); }
+.crossing-card--primary { border-color: #8cc1d2; box-shadow: inset 0 3px var(--blue), var(--shadow-sm); }
+.crossing-card h3 { margin: 0 0 4px; font-size: 1.25rem; }
+.crossing-primary-tag { display: inline-block; color: var(--blue); font-size: 0.66rem; font-weight: 850; letter-spacing: 0.08em; text-transform: uppercase; }
+.crossing-type { min-height: 54px; margin: 12px 0 6px; color: var(--muted); font-size: 0.78rem; line-height: 1.5; }
+.crossing-type span { color: #81949d; }
+.crossing-status { display: inline-flex; align-items: center; gap: 8px; margin: 12px 0 14px; padding: 8px 10px; border-radius: 999px; font-size: 0.74rem; font-weight: 850; }
+.crossing-status::before { width: 9px; height: 9px; border-radius: 50%; background: currentColor; content: ""; }
+.crossing-status--open { background: var(--green-soft); color: var(--green); }
+.crossing-status--closing { background: var(--amber-soft); color: var(--amber); }
+.crossing-status--closed { background: var(--red-soft); color: var(--red); }
+.crossing-status--unknown { background: #eaf0f2; color: var(--muted); }
+.crossing-prediction-reason { min-height: 64px; margin-bottom: 18px; color: #405b68; font-size: 0.86rem; line-height: 1.5; }
+.crossing-prediction-meta { display: grid; gap: 6px; padding-top: 15px; border-top: 1px solid #e6edef; color: var(--muted); font-size: 0.77rem; }
+.crossing-prediction-meta strong { color: var(--ink); }
 
 .crossing-observation-panel {
   display: grid;
-  grid-template-columns: 0.9fr 1.1fr;
-  gap: 34px;
-  margin: 38px 0 24px;
-  padding: clamp(22px, 4vw, 34px);
-  border-radius: 20px;
-  background: var(--crossing-surface);
-  box-shadow: var(--crossing-shadow);
+  grid-template-columns: minmax(230px, 0.72fr) minmax(0, 1.28fr);
+  gap: 28px 38px;
+  margin-bottom: 24px;
+  padding: clamp(24px, 5vw, 42px);
+  border: 1px solid var(--line);
+  border-radius: 26px;
+  background: #fff;
+  box-shadow: var(--shadow-sm);
 }
-
-.crossing-observation-panel p {
-  color: var(--crossing-muted);
-  line-height: 1.55;
-}
-
-.crossing-observation-count {
-  align-items: center;
-  gap: 10px;
-  width: fit-content;
-  margin-top: 22px;
-  padding: 10px 14px;
-  border-radius: 10px;
-  background: #edf6fc;
-  color: #245b87;
-}
-
-.crossing-observation-count:not([hidden]) { display: flex; }
+.crossing-observation-intro h2 { margin-bottom: 10px; font-size: clamp(1.6rem, 4vw, 2.35rem); }
+.crossing-observation-intro > p { color: var(--muted); line-height: 1.6; }
+.crossing-observation-count { display: inline-flex; align-items: center; gap: 10px; margin-top: 12px; padding: 10px 12px; border-radius: 12px; background: var(--blue-soft); color: var(--blue); }
+.crossing-observation-count[hidden] { display: none; }
 .crossing-observation-count strong { font-size: 1.35rem; }
-.crossing-observation-count span { max-width: 150px; font-size: 0.75rem; line-height: 1.25; }
-
-.crossing-observation-panel form { display: grid; gap: 10px; }
+.crossing-observation-count span { max-width: 120px; font-size: 0.7rem; font-weight: 750; line-height: 1.25; }
+.crossing-quick-observation { display: grid; gap: 9px; align-content: start; }
 .crossing-observation-panel label,
-.crossing-observation-panel legend { color: #334e68; font-size: 0.86rem; font-weight: 700; }
-
+.crossing-observation-panel legend { color: #304c59; font-size: 0.8rem; font-weight: 800; }
 .crossing-observation-panel input,
-.crossing-observation-panel select {
-  width: 100%;
-  margin: 0 0 6px;
-  padding: 11px 12px;
-  border: 1px solid #bcccdc;
-  border-radius: 9px;
-  background: #ffffff;
-  color: var(--crossing-ink);
-}
+.crossing-observation-panel select { width: 100%; min-height: 46px; margin: 0 0 5px; padding: 10px 12px; border: 1px solid #bfcfd5; border-radius: 11px; background: #fff; color: var(--ink); }
+.crossing-observation-panel fieldset { margin: 0 0 4px; padding: 0; border: 0; }
+.crossing-state-buttons { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 7px; margin-top: 7px; }
+.crossing-state-open { background: var(--green-soft); color: var(--green); }
+.crossing-state-warning { background: var(--amber-soft); color: var(--amber); }
+.crossing-state-closed { background: var(--red-soft); color: var(--red); }
+.crossing-state-opening { background: #e5effc; color: #285f99; }
+.crossing-form-result { min-height: 20px; margin: 0; color: var(--green); font-size: 0.8rem; line-height: 1.4; }
 
-.crossing-observation-panel fieldset { margin: 0 0 6px; padding: 0; border: 0; }
-.crossing-state-buttons { display: grid; grid-template-columns: repeat(4, 1fr); gap: 7px; margin-top: 7px; }
-.crossing-state-open { background: #d9f2e8; color: #0b6b52; }
-.crossing-state-warning { background: #fff0ce; color: #8a4b08; }
-.crossing-state-closed { background: #fee2e0; color: #9e1c14; }
-.crossing-state-opening { background: #e2ecf8; color: #245b87; }
-.crossing-form-result { min-height: 20px; margin: 0; color: var(--crossing-green) !important; font-size: 0.86rem; }
-
-.crossing-observation-history { grid-column: 1 / -1; border-top: 1px solid var(--crossing-line); padding-top: 16px; }
-.crossing-observation-history summary { color: #245b87; font-weight: 750; cursor: pointer; }
-.crossing-observation-history ol { display: grid; gap: 8px; margin: 14px 0 0; padding: 0; list-style: none; }
-.crossing-observation-history li {
-  display: grid;
-  grid-template-columns: minmax(160px, 1fr) auto;
-  gap: 3px 18px;
-  padding: 10px 12px;
-  border-radius: 9px;
-  background: #ffffff;
-  color: #334e68;
-  font-size: 0.8rem;
-}
-.crossing-observation-history time { color: var(--crossing-muted); text-align: right; }
-.crossing-observation-note { grid-column: 1 / -1; color: var(--crossing-muted); }
-.crossing-observation-sync { grid-column: 1 / -1; color: #8a4b08; font-size: 0.72rem; font-weight: 750; }
-.crossing-observation-sync--saved { color: var(--crossing-green); }
-
-.crossing-watch-panel {
-  grid-column: 1 / -1;
-  display: grid;
-  grid-template-columns: minmax(220px, 0.8fr) minmax(0, 1.2fr);
-  gap: 24px;
-  margin-top: 4px;
-  padding: 20px;
-  border: 1px solid #b9d9ee;
-  border-radius: 16px;
-  background: #f8fcff;
-}
-.crossing-watch-panel h3 { margin: 0 0 7px; font-size: 1.2rem; }
-.crossing-watch-panel label { display: block; margin-bottom: 6px; }
-.crossing-watch-panel select { margin-bottom: 10px; }
-.crossing-watch-start { width: 100%; background: var(--crossing-blue); color: #ffffff; }
+.crossing-watch-panel { grid-column: 1 / -1; display: grid; grid-template-columns: minmax(230px, 0.65fr) minmax(0, 1.35fr); gap: 26px; padding: 22px; border: 1px solid #b8d9e3; border-radius: 18px; background: linear-gradient(135deg, #f4fafc, #eef7fa); }
+.crossing-watch-panel h3 { margin-bottom: 7px; font-size: 1.25rem; }
+.crossing-watch-panel p { color: var(--muted); font-size: 0.84rem; line-height: 1.5; }
+.crossing-watch-start { width: 100%; background: var(--blue); color: #fff; }
 .crossing-watch-active { display: grid; align-content: start; gap: 12px; }
 .crossing-watch-active[hidden] { display: none; }
-.crossing-watch-status {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 4px 16px;
-  padding: 14px;
-  border-radius: 12px;
-  background: #ffffff;
-  color: #334e68;
-}
-.crossing-watch-status > strong { grid-row: 1 / 3; grid-column: 2; align-self: center; color: var(--crossing-blue); font-size: 1.45rem; }
-.crossing-watch-status > span:last-child { font-size: 0.78rem; color: var(--crossing-muted); }
+.crossing-watch-status { display: grid; grid-template-columns: 1fr auto; gap: 4px 16px; padding: 14px; border: 1px solid #d7e7ec; border-radius: 13px; background: #fff; color: #304c59; }
+.crossing-watch-status > strong { grid-row: 1 / 3; grid-column: 2; align-self: center; color: var(--blue); font-size: 1.5rem; }
+.crossing-watch-status > span:last-child { color: var(--muted); font-size: 0.75rem; }
 .crossing-watch-buttons { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 7px; }
-.crossing-watch-train { background: #dcecff; color: #175b89; }
+.crossing-watch-train { background: #dceeff; color: #17628f; }
 
-.crossing-safety-note {
-  margin: 24px 0;
-  padding: 16px 18px;
-  border-left: 5px solid var(--crossing-amber);
-  border-radius: 8px;
-  background: #fff9e9;
-  color: #69400b;
-  line-height: 1.5;
-}
+.crossing-observation-history { grid-column: 1 / -1; padding-top: 18px; border-top: 1px solid var(--line); }
+.crossing-observation-history summary { color: var(--blue); font-size: 0.84rem; font-weight: 850; cursor: pointer; }
+.crossing-observation-history ol { display: grid; gap: 8px; margin: 14px 0 0; padding: 0; list-style: none; }
+.crossing-observation-history li { display: grid; grid-template-columns: minmax(160px, 1fr) auto; gap: 4px 18px; padding: 11px 12px; border: 1px solid #e5ecef; border-radius: 11px; background: #fafcfc; color: #304c59; font-size: 0.78rem; }
+.crossing-observation-history time { color: var(--muted); text-align: right; }
+.crossing-observation-note,
+.crossing-observation-sync { grid-column: 1 / -1; color: var(--muted); }
+.crossing-observation-sync { color: var(--amber); font-size: 0.69rem; font-weight: 800; }
+.crossing-observation-sync--saved { color: var(--green); }
 
-.crossing-monitor__footer {
-  display: flex;
-  justify-content: space-between;
-  gap: 20px;
-  padding: 18px 0 34px;
-  color: var(--crossing-muted);
-  font-size: 0.78rem;
-}
+.crossing-technical-panel { margin: 22px 0; border: 1px solid var(--line); border-radius: 20px; background: rgba(255, 255, 255, 0.82); box-shadow: var(--shadow-sm); }
+.crossing-technical-panel > summary { display: flex; align-items: center; justify-content: space-between; gap: 24px; min-height: 88px; padding: 20px 24px; cursor: pointer; list-style: none; }
+.crossing-technical-panel > summary::-webkit-details-marker { display: none; }
+.crossing-technical-panel > summary > span:first-child { display: grid; gap: 2px; }
+.crossing-technical-panel > summary strong { font-size: 1.03rem; }
+.crossing-technical-panel > summary small { margin-top: 4px; color: var(--muted); line-height: 1.4; }
+.crossing-feed-status { display: inline-flex; align-items: center; gap: 7px; flex: 0 0 auto; padding: 7px 10px; border-radius: 999px; background: var(--amber-soft); color: var(--amber); font-size: 0.7rem; font-weight: 850; }
+.crossing-feed-status::before { width: 8px; height: 8px; border-radius: 50%; background: currentColor; content: ""; }
+.crossing-feed-status--connected { background: var(--green-soft); color: var(--green); }
+.crossing-feed-status--error { background: var(--red-soft); color: var(--red); }
+.crossing-feed-content { display: grid; gap: 18px; padding: 0 24px 24px; border-top: 1px solid var(--line); }
+.crossing-feed-summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); margin: 0; padding: 18px 0 0; }
+.crossing-feed-summary div { padding: 5px 16px; border-right: 1px solid var(--line); }
+.crossing-feed-summary div:first-child { padding-left: 0; }
+.crossing-feed-summary div:last-child { border-right: 0; }
+.crossing-feed-summary dt { color: var(--muted); font-size: 0.68rem; font-weight: 750; text-transform: uppercase; }
+.crossing-feed-summary dd { margin: 5px 0 0; color: var(--ink); font-size: 0.86rem; font-weight: 850; }
+.crossing-feed-events summary { color: var(--blue); font-size: 0.82rem; font-weight: 850; cursor: pointer; }
+.crossing-feed-table-wrap { overflow-x: auto; margin-top: 12px; }
+.crossing-feed-events table { width: 100%; border-collapse: collapse; background: #fff; font-size: 0.76rem; }
+.crossing-feed-events th,
+.crossing-feed-events td { padding: 9px 10px; border-bottom: 1px solid var(--line); color: #304c59; text-align: left; white-space: nowrap; }
+.crossing-feed-events th { color: var(--muted); font-size: 0.65rem; letter-spacing: 0.05em; text-transform: uppercase; }
+.crossing-feed-note { margin: 0; color: var(--muted); font-size: 0.76rem; line-height: 1.5; }
+
+.crossing-safety-note { display: flex; align-items: start; gap: 12px; margin: 22px 0; padding: 17px 18px; border: 1px solid #ecd8ae; border-radius: 15px; background: #fff9e9; color: #6d4a16; }
+.crossing-safety-note > span { display: grid; flex: 0 0 25px; height: 25px; place-items: center; border-radius: 50%; background: #e4a735; color: #fff; font-weight: 900; }
+.crossing-safety-note p { margin: 1px 0 0; font-size: 0.82rem; line-height: 1.5; }
+.crossing-monitor-footer { display: flex; justify-content: space-between; gap: 20px; padding: 16px 2px 28px; color: var(--muted); font-size: 0.72rem; }
 
 @media (max-width: 820px) {
-  .crossing-grid { grid-template-columns: 1fr; }
-  .crossing-type,
-  .crossing-prediction-reason { min-height: 0; }
-  .crossing-observation-panel { grid-template-columns: 1fr; }
-  .crossing-feed-panel { grid-template-columns: 1fr; }
+  .crossing-selection-controls,
+  .crossing-observation-panel,
   .crossing-watch-panel { grid-template-columns: 1fr; }
   .crossing-watch-buttons { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .crossing-feed-summary { grid-template-columns: 1fr 1fr; }
+  .crossing-feed-summary div { border-right: 0; border-bottom: 1px solid var(--line); padding: 10px 0; }
 }
 
-@media (max-width: 520px) {
-  .level-crossing-page .site-main > .site-shell { width: min(100% - 22px, 1120px); }
-  .crossing-route-advice { border-radius: 18px; }
-  .crossing-selection-heading { display: grid; }
+@media (max-width: 560px) {
+  .crossing-app-bar { min-height: 68px; padding: 10px 14px; }
+  .crossing-brand-mark { width: 40px; height: 40px; }
+  .crossing-brand small,
+  .crossing-cxms-link { display: none; }
+  .crossing-mode-badge { max-width: 128px; justify-content: center; text-align: center; }
+  .crossing-app-shell { width: min(calc(100% - 20px), 1180px); padding-top: 18px; }
+  .crossing-selection-panel { border-radius: 19px; }
+  .crossing-selection-heading { display: grid; gap: 15px; }
   .crossing-selection-heading .crossing-button { width: 100%; }
+  .crossing-selection-chips { grid-template-columns: 1fr; }
   .crossing-selection-option { grid-template-columns: 1fr; }
-  .crossing-primary-choice { margin-left: 28px; }
+  .crossing-primary-choice { margin-left: 29px; }
+  .crossing-route-advice { min-height: 280px; margin-bottom: 38px; border-radius: 22px; }
+  .crossing-route-advice h2 { font-size: clamp(2.4rem, 14vw, 4rem); }
+  .crossing-section-heading { align-items: start; }
+  .crossing-section-heading .crossing-button { min-height: 42px; padding: 8px 11px; font-size: 0.72rem; }
+  .crossing-observation-panel { padding: 22px 16px; border-radius: 20px; }
   .crossing-state-buttons { grid-template-columns: 1fr 1fr; }
   .crossing-observation-history li { grid-template-columns: 1fr; }
   .crossing-observation-history time { text-align: left; }
-  .crossing-monitor__footer { flex-direction: column; }
+  .crossing-technical-panel > summary { align-items: start; padding: 18px; }
+  .crossing-technical-panel > summary small { display: none; }
+  .crossing-feed-content { padding: 0 18px 18px; }
+  .crossing-monitor-footer { flex-direction: column; gap: 5px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * { scroll-behavior: auto !important; transition: none !important; }
 }

--- a/static/js/level-crossing.js
+++ b/static/js/level-crossing.js
@@ -149,17 +149,45 @@
     }
   }
 
+  function displayStatusFor(crossing, now = new Date()) {
+    const latest = readObservations().find((observation) => {
+      if (observation.crossingId !== crossing.id || observation.state === "TRAIN_PASSED") return false;
+      const age = now.getTime() - new Date(observation.observedAt).getTime();
+      return Number.isFinite(age) && age >= 0 && age <= 10 * 60 * 1000;
+    });
+    if (latest) {
+      const className = latest.state === "OPEN"
+        ? "open"
+        : latest.state === "CLOSED" ? "closed" : "closing";
+      return { label: `${observationLabels[latest.state] || latest.state} · seen`, className };
+    }
+    const prediction = predict(crossing, now);
+    const className = prediction.state === "OPEN"
+      ? "open"
+      : prediction.state === "LIKELY_CLOSED" ? "closed" : "closing";
+    return { label: `${stateDetails[prediction.state][0]} · est.`, className };
+  }
+
+  function renderSelectionChips() {
+    const selected = selectedCrossings();
+    elements.selectionChips.innerHTML = selected.length
+      ? selected.map((crossing) => {
+          const status = displayStatusFor(crossing);
+          return `<span class="crossing-selection-chip${crossing.id === preferences.primaryId ? " crossing-selection-chip--primary" : ""}">
+            <span class="crossing-selection-chip-name">${crossing.id === preferences.primaryId ? '<span aria-label="Primary crossing">★</span>' : ""}${escapeHtml(crossing.name)}</span>
+            <span class="crossing-selection-chip-state crossing-selection-chip-state--${status.className}">${escapeHtml(status.label)}</span>
+          </span>`;
+        }).join("")
+      : '<span class="crossing-selection-empty">No crossings selected</span>';
+  }
+
   function renderSelection() {
     ensurePrimary();
     const selected = selectedCrossings();
     elements.selectionSummary.textContent = selected.length
       ? `${selected.length} crossing${selected.length === 1 ? "" : "s"} selected. The star marks the crossing used for route advice.`
       : "No crossings selected. Choose at least one to see predictions and record observations.";
-    elements.selectionChips.innerHTML = selected.length
-      ? selected.map((crossing) => `<span class="crossing-selection-chip${crossing.id === preferences.primaryId ? " crossing-selection-chip--primary" : ""}">
-          ${crossing.id === preferences.primaryId ? '<span aria-hidden="true">★</span>' : ""}${escapeHtml(crossing.name)}
-        </span>`).join("")
-      : '<span class="crossing-selection-empty">None selected</span>';
+    renderSelectionChips();
 
     elements.selectionOptions.innerHTML = crossings.map((crossing) => {
       const selectedHere = preferences.selectedIds.includes(crossing.id);
@@ -386,12 +414,14 @@
     };
     writeObservations([observation, ...readObservations()]);
     renderObservations();
+    renderSelectionChips();
     void syncObservation(observation);
     return observation;
   }
 
   function renderPredictions() {
     const now = new Date();
+    renderSelectionChips();
     const selected = selectedCrossings();
     const predictions = selected.map((crossing) => ({ crossing, prediction: predict(crossing, now) }));
     const primary = predictions.find(({ crossing }) => crossing.id === preferences.primaryId);
@@ -494,7 +524,7 @@
     const opening = elements.selectionControls.hidden;
     elements.selectionControls.hidden = !opening;
     elements.selectionToggle.setAttribute("aria-expanded", String(opening));
-    elements.selectionToggle.textContent = opening ? "Done" : "Change selection";
+    elements.selectionToggle.textContent = opening ? "Done" : "Edit crossings";
   });
 
   elements.selectionOptions.addEventListener("change", (event) => {

--- a/templates/level-crossing.html
+++ b/templates/level-crossing.html
@@ -1,166 +1,167 @@
-{% extends "base.html" %}
-
-{% block title %}Chichester Crossing Monitor — CXMS{% endblock %}
-
-{% block head_extra %}
-  <meta name="description" content="Predicted status for Whyke Road, Stockbridge Road and Basin Road level crossings, with route guidance into Chichester.">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/level-crossing.css') }}?v=3">
-{% endblock %}
-
-{% block body_class %} level-crossing-page{% endblock %}
-
-{% block content %}
-<section class="crossing-monitor" id="crossing-monitor">
-  <header class="crossing-monitor__header">
-    <div>
-      <p class="crossing-eyebrow">Chichester route helper</p>
-      <h1>Crossing Monitor</h1>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#071d2b">
+  <meta name="description" content="Predicted status for selected level crossings, with route guidance and live Network Rail calibration.">
+  <title>Chichester Crossing Monitor</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/level-crossing.css') }}?v=4">
+</head>
+<body class="level-crossing-page">
+  <header class="crossing-app-bar">
+    <a class="crossing-brand" href="/level-crossing" aria-label="Crossing Monitor home">
+      <span class="crossing-brand-mark" aria-hidden="true">
+        <svg viewBox="0 0 44 44" role="img">
+          <path d="M8 34h28M12 39h20M14 30l16-16M17 11l16 16M13 10l21 21"/>
+          <circle cx="13" cy="10" r="3"/><circle cx="34" cy="31" r="3"/>
+        </svg>
+      </span>
+      <span><strong>Crossing</strong><small>Chichester live route helper</small></span>
+    </a>
+    <div class="crossing-app-actions">
+      <span class="crossing-mode-badge">Simulation mode</span>
+      <a class="crossing-cxms-link" href="/">CXMS</a>
     </div>
-    <span class="crossing-mode-badge">Simulation mode</span>
   </header>
 
-  <section class="crossing-selection-panel" aria-labelledby="crossing-selection-title">
-    <div class="crossing-selection-heading">
-      <div>
-        <p class="crossing-eyebrow">Your local view</p>
-        <h2 id="crossing-selection-title">Selected level crossings</h2>
-        <p id="crossing-selection-summary">Choose the crossings you want to monitor.</p>
-      </div>
-      <button id="crossing-selection-toggle" class="crossing-button crossing-button--secondary" type="button" aria-expanded="false" aria-controls="crossing-selection-controls">Change selection</button>
-    </div>
-    <div id="crossing-selection-chips" class="crossing-selection-chips" aria-live="polite"></div>
-    <div id="crossing-selection-controls" class="crossing-selection-controls" hidden>
-      <h3>Chichester</h3>
-      <p>Select crossings to show, then choose one as the primary crossing for route advice.</p>
-      <div id="crossing-selection-options"></div>
-    </div>
-  </section>
-
-  <section id="crossing-route-advice" class="crossing-route-advice" aria-live="polite">
-    <p class="crossing-eyebrow">Best route into town</p>
-    <h2>Checking the crossings…</h2>
-  </section>
-
-  <div class="crossing-section-heading">
-    <div>
-      <p class="crossing-eyebrow">Local view</p>
-      <h2>Chichester crossings</h2>
-    </div>
-    <button id="crossing-refresh" class="crossing-button crossing-button--secondary" type="button">Refresh</button>
-  </div>
-
-  <section id="crossing-grid" class="crossing-grid" aria-live="polite"></section>
-
-  <section class="crossing-feed-panel" aria-labelledby="crossing-feed-title">
-    <div>
-      <p class="crossing-eyebrow">Network Rail Train Describer</p>
-      <h2 id="crossing-feed-title">Live feed calibration</h2>
-      <p id="crossing-feed-copy">Checking the server-side TD connection…</p>
-    </div>
-    <div class="crossing-feed-summary">
-      <span id="crossing-feed-status" class="crossing-feed-status">Connecting</span>
-      <dl>
-        <div><dt>TD area</dt><dd id="crossing-feed-area">CH</dd></div>
-        <div><dt>Feed frames</dt><dd id="crossing-feed-frames">0</dd></div>
-        <div><dt>CH messages</dt><dd id="crossing-feed-count">0</dd></div>
-        <div><dt>Last message</dt><dd id="crossing-feed-updated">Waiting</dd></div>
-      </dl>
-    </div>
-    <details id="crossing-feed-events" class="crossing-feed-events" hidden>
-      <summary>Recent Chichester berth movements</summary>
-      <div class="crossing-feed-table-wrap">
-        <table>
-          <thead><tr><th>Received</th><th>Type</th><th>Movement</th><th>Train</th></tr></thead>
-          <tbody id="crossing-feed-event-rows"></tbody>
-        </table>
-      </div>
-    </details>
-    <p class="crossing-feed-note">
-      Live messages are being observed to identify the approach and clearing berths. They do not
-      change the crossing prediction until that mapping has been calibrated.
-    </p>
-  </section>
-
-  <section class="crossing-observation-panel">
-    <div>
-      <p class="crossing-eyebrow">Calibration</p>
-      <h2>What can you see?</h2>
-      <p>
-        Log the physical barrier state when you happen to observe it. Records save immediately on
-        this device, then sync anonymously with the surrounding signalling messages when central
-        storage is available.
-      </p>
-      <div id="crossing-observation-count" class="crossing-observation-count" hidden>
-        <strong>0</strong>
-        <span>observations saved on this device</span>
-      </div>
-    </div>
-
-    <form id="crossing-observation-form">
-      <label for="crossing-observation-select">Crossing</label>
-      <select id="crossing-observation-select" name="crossingId"></select>
-
-      <fieldset>
-        <legend>Barrier state</legend>
-        <div class="crossing-state-buttons">
-          <button type="submit" name="state" value="OPEN" class="crossing-button crossing-state-open">Open</button>
-          <button type="submit" name="state" value="CLOSING" class="crossing-button crossing-state-warning">Closing</button>
-          <button type="submit" name="state" value="CLOSED" class="crossing-button crossing-state-closed">Closed</button>
-          <button type="submit" name="state" value="OPENING" class="crossing-button crossing-state-opening">Opening</button>
+  <main class="crossing-app-shell">
+    <section class="crossing-selection-panel" aria-labelledby="crossing-selection-title">
+      <div class="crossing-selection-heading">
+        <div>
+          <p class="crossing-eyebrow">Your local view</p>
+          <h1 id="crossing-selection-title">Selected level crossings</h1>
+          <p id="crossing-selection-summary">Choose the crossings you want to monitor.</p>
         </div>
-      </fieldset>
-
-      <label for="crossing-observation-note">Optional note</label>
-      <input id="crossing-observation-note" name="note" maxlength="300" placeholder="For example: second train approaching">
-      <p id="crossing-observation-result" class="crossing-form-result" aria-live="polite"></p>
-    </form>
-
-    <section class="crossing-watch-panel" aria-labelledby="crossing-watch-title">
-      <div class="crossing-watch-intro">
-        <p class="crossing-eyebrow">Optional field session</p>
-        <h3 id="crossing-watch-title">Watch one complete barrier cycle</h3>
-        <p>Start only when safely parked or standing away from the road. Each tap is timestamped automatically.</p>
-        <label for="crossing-watch-select">Crossing</label>
-        <select id="crossing-watch-select"></select>
-        <button id="crossing-watch-start" class="crossing-button crossing-watch-start" type="button">Start watch session</button>
+        <button id="crossing-selection-toggle" class="crossing-button crossing-button--quiet" type="button" aria-expanded="false" aria-controls="crossing-selection-controls">Edit crossings</button>
       </div>
-      <div id="crossing-watch-active" class="crossing-watch-active" hidden>
-        <div class="crossing-watch-status">
-          <span id="crossing-watch-name">Watching</span>
-          <strong id="crossing-watch-elapsed">00:00</strong>
-          <span><strong id="crossing-watch-train-count">0</strong> trains recorded</span>
+      <div id="crossing-selection-chips" class="crossing-selection-chips" aria-live="polite"></div>
+      <div id="crossing-selection-controls" class="crossing-selection-controls" hidden>
+        <div>
+          <h2>Chichester</h2>
+          <p>Select crossings to show, then choose the primary crossing used for route advice.</p>
         </div>
-        <div class="crossing-watch-buttons">
-          <button type="button" data-watch-state="CLOSING" class="crossing-button crossing-state-warning">Closing</button>
-          <button type="button" data-watch-state="CLOSED" class="crossing-button crossing-state-closed">Closed</button>
-          <button type="button" data-watch-state="TRAIN_PASSED" class="crossing-button crossing-watch-train">Train passed</button>
-          <button type="button" data-watch-state="OPENING" class="crossing-button crossing-state-opening">Opening</button>
-          <button type="button" data-watch-state="OPEN" class="crossing-button crossing-state-open">Open</button>
-        </div>
-        <button id="crossing-watch-finish" class="crossing-button crossing-button--secondary" type="button">Finish session</button>
-        <p id="crossing-watch-result" class="crossing-form-result" aria-live="polite"></p>
+        <div id="crossing-selection-options"></div>
       </div>
     </section>
 
-    <details id="crossing-observation-history" class="crossing-observation-history" hidden>
-      <summary>Recent observations on this device</summary>
-      <ol id="crossing-observation-rows"></ol>
+    <section id="crossing-route-advice" class="crossing-route-advice" aria-live="polite">
+      <p class="crossing-eyebrow">Best route into town</p>
+      <h2>Checking the crossings…</h2>
+    </section>
+
+    <section class="crossing-local-section" aria-labelledby="crossing-local-title">
+      <div class="crossing-section-heading">
+        <div>
+          <p class="crossing-eyebrow">At a glance</p>
+          <h2 id="crossing-local-title">Crossing detail</h2>
+        </div>
+        <button id="crossing-refresh" class="crossing-button crossing-button--quiet" type="button">Refresh status</button>
+      </div>
+      <div id="crossing-grid" class="crossing-grid" aria-live="polite"></div>
+    </section>
+
+    <section class="crossing-observation-panel" aria-labelledby="crossing-observation-title">
+      <div class="crossing-observation-intro">
+        <p class="crossing-eyebrow">Help improve predictions</p>
+        <h2 id="crossing-observation-title">What can you see?</h2>
+        <p>Record the barrier state when safely stationary. It saves immediately on this device, then syncs anonymously with the surrounding signalling messages.</p>
+        <div id="crossing-observation-count" class="crossing-observation-count" hidden>
+          <strong>0</strong>
+          <span>observations on this device</span>
+        </div>
+      </div>
+
+      <form id="crossing-observation-form" class="crossing-quick-observation">
+        <label for="crossing-observation-select">Crossing</label>
+        <select id="crossing-observation-select" name="crossingId"></select>
+        <fieldset>
+          <legend>Barrier state now</legend>
+          <div class="crossing-state-buttons">
+            <button type="submit" name="state" value="OPEN" class="crossing-button crossing-state-open">Open</button>
+            <button type="submit" name="state" value="CLOSING" class="crossing-button crossing-state-warning">Closing</button>
+            <button type="submit" name="state" value="CLOSED" class="crossing-button crossing-state-closed">Closed</button>
+            <button type="submit" name="state" value="OPENING" class="crossing-button crossing-state-opening">Opening</button>
+          </div>
+        </fieldset>
+        <label for="crossing-observation-note">Optional note</label>
+        <input id="crossing-observation-note" name="note" maxlength="300" placeholder="For example: second train approaching">
+        <p id="crossing-observation-result" class="crossing-form-result" aria-live="polite"></p>
+      </form>
+
+      <section class="crossing-watch-panel" aria-labelledby="crossing-watch-title">
+        <div class="crossing-watch-intro">
+          <p class="crossing-eyebrow">Optional field session</p>
+          <h3 id="crossing-watch-title">Watch one barrier cycle</h3>
+          <p>One short session gives us accurate closing, train and reopening timestamps.</p>
+          <label for="crossing-watch-select">Crossing</label>
+          <select id="crossing-watch-select"></select>
+          <button id="crossing-watch-start" class="crossing-button crossing-watch-start" type="button">Start watch session</button>
+        </div>
+        <div id="crossing-watch-active" class="crossing-watch-active" hidden>
+          <div class="crossing-watch-status">
+            <span id="crossing-watch-name">Watching</span>
+            <strong id="crossing-watch-elapsed">00:00</strong>
+            <span><strong id="crossing-watch-train-count">0</strong> trains recorded</span>
+          </div>
+          <div class="crossing-watch-buttons">
+            <button type="button" data-watch-state="CLOSING" class="crossing-button crossing-state-warning">Closing</button>
+            <button type="button" data-watch-state="CLOSED" class="crossing-button crossing-state-closed">Closed</button>
+            <button type="button" data-watch-state="TRAIN_PASSED" class="crossing-button crossing-watch-train">Train passed</button>
+            <button type="button" data-watch-state="OPENING" class="crossing-button crossing-state-opening">Opening</button>
+            <button type="button" data-watch-state="OPEN" class="crossing-button crossing-state-open">Open</button>
+          </div>
+          <button id="crossing-watch-finish" class="crossing-button crossing-button--quiet" type="button">Finish session</button>
+          <p id="crossing-watch-result" class="crossing-form-result" aria-live="polite"></p>
+        </div>
+      </section>
+
+      <details id="crossing-observation-history" class="crossing-observation-history" hidden>
+        <summary>Recent observations on this device</summary>
+        <ol id="crossing-observation-rows"></ol>
+      </details>
+    </section>
+
+    <details class="crossing-technical-panel">
+      <summary>
+        <span>
+          <span class="crossing-eyebrow">Network Rail Train Describer</span>
+          <strong>Live calibration feed</strong>
+          <small id="crossing-feed-copy">Checking the server-side TD connection…</small>
+        </span>
+        <span id="crossing-feed-status" class="crossing-feed-status">Connecting</span>
+      </summary>
+      <div class="crossing-feed-content">
+        <dl class="crossing-feed-summary">
+          <div><dt>TD area</dt><dd id="crossing-feed-area">CH</dd></div>
+          <div><dt>Feed frames</dt><dd id="crossing-feed-frames">0</dd></div>
+          <div><dt>CH messages</dt><dd id="crossing-feed-count">0</dd></div>
+          <div><dt>Last message</dt><dd id="crossing-feed-updated">Waiting</dd></div>
+        </dl>
+        <details id="crossing-feed-events" class="crossing-feed-events" hidden>
+          <summary>Recent Chichester berth movements</summary>
+          <div class="crossing-feed-table-wrap">
+            <table>
+              <thead><tr><th>Received</th><th>Type</th><th>Movement</th><th>Train</th></tr></thead>
+              <tbody id="crossing-feed-event-rows"></tbody>
+            </table>
+          </div>
+        </details>
+        <p class="crossing-feed-note">Live messages help identify approach and clearing berths. They do not change the route prediction until the mapping has been calibrated.</p>
+      </div>
     </details>
-  </section>
 
-  <aside class="crossing-safety-note">
-    <strong>Route-planning prediction only.</strong>
-    Never use this app to decide whether it is safe to cross. Always obey the physical lights,
-    alarms, gates and barriers.
-  </aside>
+    <aside class="crossing-safety-note">
+      <span aria-hidden="true">!</span>
+      <p><strong>Route-planning prediction only.</strong> Never use this app to decide whether it is safe to cross. Always obey the physical lights, alarms, gates and barriers.</p>
+    </aside>
 
-  <footer class="crossing-monitor__footer">
-    <span id="crossing-last-updated">Preparing local predictions</span>
-    <span>Whyke Road · Stockbridge Road · Basin Road</span>
-  </footer>
-</section>
-{% endblock %}
+    <footer class="crossing-monitor-footer">
+      <span id="crossing-last-updated">Preparing local predictions</span>
+      <span>Whyke Road · Basin Road · Stockbridge Road</span>
+    </footer>
+  </main>
 
-{% block scripts %}
-  <script src="{{ url_for('static', filename='js/level-crossing.js') }}?v=3"></script>
-{% endblock %}
+  <script src="{{ url_for('static', filename='js/level-crossing.js') }}?v=4"></script>
+</body>
+</html>

--- a/tests/test_level_crossing.py
+++ b/tests/test_level_crossing.py
@@ -28,10 +28,13 @@ class LevelCrossingPageTests(unittest.TestCase):
         self.assertIn(b"Recent observations on this device", response.data)
         self.assertIn(b"Selected level crossings", response.data)
         self.assertIn(b"Start watch session", response.data)
+        self.assertIn(b"Chichester live route helper", response.data)
         css_response = self.client.get("/static/css/level-crossing.css")
         js_response = self.client.get("/static/js/level-crossing.js")
         self.assertEqual(css_response.status_code, 200)
         self.assertEqual(js_response.status_code, 200)
+        self.assertIn(b"crossing-app-bar", css_response.data)
+        self.assertIn(b"crossing-selection-chip-state", js_response.data)
         css_response.close()
         js_response.close()
 


### PR DESCRIPTION
## What changed

- replaces the inherited CXMS page chrome with a focused standalone Crossing app shell
- gives every selected crossing a prominent status indicator at the top of the first screen
- labels demonstration states as `est.` and recent field observations as `seen`
- lets observations from the last ten minutes override the corresponding summary indicator
- strengthens the route-advice hierarchy and modernises cards, controls, spacing, colour and typography
- moves observation tools ahead of technical data and collapses the raw TD feed behind progressive disclosure
- improves mobile stacking, tap targets, keyboard focus, contrast and reduced-motion support

## UX rationale

The redesign prioritises the two questions a normal user has: **what are the selected crossings doing?** and **which route should I take?** Calibration and raw signalling remain available without dominating the task flow.

## Validation

- JavaScript and Python syntax checks passed
- crossing-specific suite: 11 tests passed
- full CXMS suite: 119 tests passed
- DOM interaction check loaded the real Flask page and verified three initial status indicators, recent-observation override, crossing deselection, card updates and zero runtime errors
- published blob hashes match the reviewed local files